### PR TITLE
ci: push image to GHCR on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build Docker Image
 
-# P0 gate: prove the multi-arch image builds. No registry push yet (that lands in
-# the distribution phase). Buildx with QEMU emulation builds amd64 + arm64.
+# Build the multi-arch image and, on main, push it to GHCR so it can be pulled on the
+# Unraid box (e.g. for the integration spike). Pull requests build only (no push).
 on:
   push:
     branches: [main]
@@ -14,8 +14,10 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
+  IMAGE: ghcr.io/${{ github.repository }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -26,11 +28,32 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - name: Build multi-arch image (no push)
+
+      # Push only on main / manual runs, never from pull requests.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build multi-arch image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds GHCR login + push to the multi-arch build on `main` (and manual runs); pull requests still build-only. Enables pulling `ghcr.io/junkerderprovinz/bombvault` on the Unraid box to run the integration spike. Adds `packages: write` permission + metadata-action tags (`latest` + short SHA).