### PR TITLE
fix(backup): translate host appdata paths to the container mount

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -101,35 +101,47 @@ func (s *Service) EnsureRepo(ctx context.Context, repo string, mode restic.Mode)
 	return nil
 }
 
-// resolveAppdataPaths returns the host paths to back up for a container. It uses
-// the inspect's bind mounts whose source lives under <HostMountRoot>/appdata
-// (the Unraid convention). If none match, it falls back to the conventional
-// per-container appdata directory <HostMountRoot>/appdata/<name>.
+// resolveAppdataPaths returns the CONTAINER-VISIBLE paths to back up for a
+// container. Docker reports bind-mount sources as HOST paths (e.g.
+// /mnt/user/appdata/<x>), but BombVault can only read them through the broad
+// host mount (default host HostSourceRoot=/mnt/user → container
+// HostMountRoot=/host/user). So we TRANSLATE every appdata bind source from the
+// host share root to the container mount root and back up the real, correctly
+// cased path — not a guess. Non-appdata binds (media libraries, /etc/localtime,
+// cache pools outside the share) are skipped.
 //
-// ASSUMPTION (documented): appdata lives at <HostMountRoot>/appdata. The broad
-// host mount (default host /mnt/user → /host/user) makes the container's own
-// appdata reachable at that path for the backup.
+// Fallback (no appdata bind found): the conventional <HostMountRoot>/appdata/<name>.
 func (s *Service) resolveAppdataPaths(name string, in model.Inspect) []string {
-	appdataRoot := path.Join(s.cfg.HostMountRoot, "appdata")
-	prefix := appdataRoot + "/"
+	hostAppdata := path.Join(path.Clean(s.cfg.HostSourceRoot), "appdata") // /mnt/user/appdata
+	hostPrefix := hostAppdata + "/"
+	containerAppdata := path.Join(s.cfg.HostMountRoot, "appdata") // /host/user/appdata
+	containerPrefix := containerAppdata + "/"
 
 	var out []string
 	seen := map[string]bool{}
 	for _, m := range in.Mounts {
-		src := m.Source
-		if src == "" {
+		if m.Source == "" {
 			continue
 		}
-		clean := path.Clean(src)
-		if clean == appdataRoot || strings.HasPrefix(clean, prefix) {
-			if !seen[clean] {
-				out = append(out, clean)
-				seen[clean] = true
-			}
+		src := path.Clean(m.Source)
+		var container string
+		switch {
+		case src == hostAppdata:
+			container = containerAppdata
+		case strings.HasPrefix(src, hostPrefix):
+			container = containerAppdata + "/" + strings.TrimPrefix(src, hostPrefix)
+		case src == containerAppdata || strings.HasPrefix(src, containerPrefix):
+			container = src // already container-visible (odd setups / tests)
+		default:
+			continue // not an appdata bind under the user share — skip
+		}
+		if !seen[container] {
+			out = append(out, container)
+			seen[container] = true
 		}
 	}
 	if len(out) == 0 {
-		out = append(out, path.Join(appdataRoot, name))
+		out = append(out, path.Join(containerAppdata, name))
 	}
 	return out
 }

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -151,6 +151,55 @@ func TestServiceBackupResolvesAppdataFromMounts(t *testing.T) {
 	}
 }
 
+// TestServiceBackupTranslatesHostAppdataPath pins the host→container path fix:
+// Docker reports the bind source as the HOST path (/mnt/user/appdata/<x>), which
+// BombVault must translate to the container-visible HostMountRoot path before
+// handing it to restic — using the real, correctly cased directory, not a guess.
+func TestServiceBackupTranslatesHostAppdataPath(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.ToSlash(dir)
+	cfg := config.Config{
+		AppKey:         strings.Repeat("a", 64),
+		DataDir:        dir,
+		HostMountRoot:  root,        // container side of the broad mount
+		HostSourceRoot: "/mnt/user", // host side reported by docker inspect
+	}
+	st := newMemStore(t)
+	s := mustSettings(t, st)
+	s.EncryptionEnabled = false
+	s.ContainersPath = "backups/containers"
+	if err := st.UpdateSettings(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real dir is lowercase though the container name is mixed-case — a guess
+	// (<root>/appdata/Pingvin-Share-X) would be wrong; the translation is right.
+	d := &fakeServiceDocker{inspect: model.Inspect{
+		Name:  "/Pingvin-Share-X",
+		Image: "smp46/pingvin-share-x:latest",
+		Mounts: []model.Mount{
+			{Type: "bind", Source: "/mnt/user/appdata/pingvin-share-x", Destination: "/data"},
+			{Type: "bind", Source: "/mnt/user/Media", Destination: "/media"}, // not appdata → excluded
+			{Type: "bind", Source: "/etc/localtime", Destination: "/etc/localtime"},
+		},
+	}}
+	eng := &fakeResticEngine{}
+	svc := api.NewService(cfg, st, d, eng)
+
+	if _, err := svc.Backup(context.Background(), "Pingvin-Share-X"); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	want := root + "/appdata/pingvin-share-x"
+	if !contains(eng.lastPaths, want) {
+		t.Fatalf("expected translated container path %q, got %v", want, eng.lastPaths)
+	}
+	for _, p := range eng.lastPaths {
+		if strings.Contains(p, "Media") || p == "/etc/localtime" {
+			t.Fatalf("non-appdata mount must be excluded, got %v", eng.lastPaths)
+		}
+	}
+}
+
 // TestServiceSetIncludeFindOrCreate verifies that SetInclude creates the target
 // row when it does not exist yet, rather than returning an error.
 func TestServiceSetIncludeFindOrCreate(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AppKey            string
 	DataDir           string
 	HostMountRoot     string
+	HostSourceRoot    string
 	Port              int
 	HTTPSPort         int
 	HTTPOnly          bool
@@ -37,6 +38,7 @@ func Load(env map[string]string) (Config, error) {
 		AppKey:            key,
 		DataDir:           stringOr(env["DATA_DIR"], "/config"),
 		HostMountRoot:     stringOr(env["HOST_MOUNT_ROOT"], "/host/user"),
+		HostSourceRoot:    stringOr(env["HOST_SOURCE_ROOT"], "/mnt/user"),
 		Port:              intOr(env["PORT"], 3000),
 		HTTPSPort:         intOr(env["HTTPS_PORT"], 3443),
 		HTTPOnly:          strings.EqualFold(env["HTTP_ONLY"], "true"),


### PR DESCRIPTION
Fixes the box-gate backup failure (restic: `/host/user/appdata/<Name> does not exist`). Docker inspect reports bind sources as HOST paths (/mnt/user/appdata/<x>), but BombVault reads them through the broad mount at /host/user/...; resolveAppdataPaths now TRANSLATES host appdata sources to the container path via the new HOST_SOURCE_ROOT (default /mnt/user) and backs up the real, correctly-cased dir instead of a guess. Non-appdata binds (media, /etc/localtime) are excluded. Adds a regression test pinning the translation + exclusions.