### PR TITLE
Phase 1.1: i18n + theme fixes, container sort, schedule builder, folder picker

### DIFF
--- a/cmd/bombvault/main.go
+++ b/cmd/bombvault/main.go
@@ -62,8 +62,12 @@ func run() error {
 		},
 		st.ListTargets,
 	)
+	// Build the containers LastRunFunc: the everyN due-gate queries the most
+	// recent successful backup across all container targets.
+	containersLastRun := schedule.LastRunFunc(st.LastSuccessfulContainerBackup)
+
 	if settings, sErr := st.GetSettings(); sErr == nil {
-		if rErr := scheduler.Reload(settings); rErr != nil {
+		if rErr := scheduler.ReloadWithDueChecks(settings, containersLastRun, nil, nil); rErr != nil {
 			log.Printf("scheduler: initial reload failed: %v", rErr)
 		}
 	} else {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -54,6 +54,7 @@ func (h *Handler) Router() http.Handler {
 	mux.HandleFunc("PUT /api/settings", h.handlePutSettings)
 	mux.HandleFunc("POST /api/spike", h.handleSpike)
 	mux.HandleFunc("GET /api/runs", h.handleRuns)
+	mux.HandleFunc("GET /api/browse", h.handleBrowse)
 
 	return mux
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,12 +12,14 @@ import (
 
 // Handler bundles the JSON API dependencies and builds the router.
 type Handler struct {
-	cfg       config.Config
-	store     *store.Repo
-	docker    dockercli.Docker
-	svc       *Service
-	scheduler *schedule.Scheduler
-	probes    []spike.Probe
+	cfg               config.Config
+	store             *store.Repo
+	docker            dockercli.Docker
+	svc               *Service
+	scheduler         *schedule.Scheduler
+	probes            []spike.Probe
+	// containersLastRun is used by the everyN due-gate in ReloadWithDueChecks.
+	containersLastRun schedule.LastRunFunc
 }
 
 // NewHandler constructs the API handler.
@@ -30,12 +32,13 @@ func NewHandler(
 	probes []spike.Probe,
 ) *Handler {
 	return &Handler{
-		cfg:       cfg,
-		store:     st,
-		docker:    d,
-		svc:       svc,
-		scheduler: scheduler,
-		probes:    probes,
+		cfg:               cfg,
+		store:             st,
+		docker:            d,
+		svc:               svc,
+		scheduler:         scheduler,
+		probes:            probes,
+		containersLastRun: schedule.LastRunFunc(st.LastSuccessfulContainerBackup),
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/junkerderprovinz/bombvault/internal/backup"
@@ -95,6 +97,7 @@ type containerView struct {
 	Image             string `json:"image"`
 	State             string `json:"state"`
 	Status            string `json:"status"`
+	IP                string `json:"ip"`
 	IncludeInSchedule bool   `json:"includeInSchedule"`
 	LastBackup        *int64 `json:"lastBackup"`
 }
@@ -120,6 +123,7 @@ func (h *Handler) handleListContainers(w http.ResponseWriter, r *http.Request) {
 			Image:  c.Image,
 			State:  c.State,
 			Status: c.Status,
+			IP:     c.IP,
 		}
 		if t, ok := byName[c.Name]; ok {
 			v.IncludeInSchedule = t.IncludeInSchedule
@@ -257,7 +261,7 @@ func (h *Handler) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Validate each cadence parses.
 	for _, cad := range []string{v.ContainersSchedule, v.VMsSchedule, v.FlashSchedule} {
-		if _, _, err := schedule.ParseCadence(cad); err != nil {
+		if _, err := schedule.ParseCadence(cad); err != nil {
 			writeJSON(w, http.StatusOK, map[string]any{
 				"ok": false, "error": scrubError(err),
 			})
@@ -313,4 +317,81 @@ func (h *Handler) handleRuns(w http.ResponseWriter, _ *http.Request) {
 		runs = []store.Run{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "runs": runs})
+}
+
+// browseDirEntry is a single subdirectory entry in the browse response.
+type browseDirEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"` // relative to HostMountRoot (e.g. "appdata/plex")
+}
+
+// handleBrowse serves GET /api/browse?path=<subpath>.
+// It lists the immediate subdirectories of <HostMountRoot>/<subpath>,
+// excluding hidden entries (dot-prefixed names), sorted alphabetically.
+//
+// The response is always HTTP 200; errors use {ok:false,error} so the UI can
+// display a graceful message. A missing or empty `path` query parameter lists
+// the mount root itself.
+func (h *Handler) handleBrowse(w http.ResponseWriter, r *http.Request) {
+	subpath := r.URL.Query().Get("path")
+
+	// Resolve the absolute path to read.
+	// An empty subpath lists the mount root itself — paths.Resolve requires a
+	// non-empty child (strict containment), so we use the root directly.
+	var abs string
+	if subpath == "" {
+		abs = h.cfg.HostMountRoot
+	} else {
+		var err error
+		abs, err = paths.Resolve(h.cfg.HostMountRoot, subpath)
+		if err != nil {
+			// paths.Resolve returns ErrTraversal or ErrAbsoluteSub — neither
+			// leaks host paths; report a generic message for defense-in-depth.
+			writeJSON(w, http.StatusOK, map[string]any{
+				"ok":    false,
+				"error": "invalid path: must be a relative subpath under the mount root",
+			})
+			return
+		}
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		log.Printf("api: browse: ReadDir %q: %v", abs, err) //nolint:gosec // G706: abs is always either cfg.HostMountRoot or a Resolve-validated child path; no raw user bytes reach the log formatter
+		writeJSON(w, http.StatusOK, map[string]any{
+			"ok":    false,
+			"error": "could not read directory",
+		})
+		return
+	}
+
+	dirs := make([]browseDirEntry, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue // skip hidden entries
+		}
+		// Build the relative path from HostMountRoot to this entry.
+		var rel string
+		if subpath == "" {
+			rel = name
+		} else {
+			rel = subpath + "/" + name
+		}
+		dirs = append(dirs, browseDirEntry{Name: name, Path: rel})
+	}
+
+	// os.ReadDir returns entries in directory order (usually alphabetical on
+	// most filesystems), but sort explicitly to guarantee it.
+	sort.Slice(dirs, func(i, j int) bool { return dirs[i].Name < dirs[j].Name })
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":   true,
+		"root": h.cfg.HostMountRoot,
+		"path": subpath,
+		"dirs": dirs,
+	})
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -286,7 +286,7 @@ func (h *Handler) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, failEnvelope(err))
 		return
 	}
-	if err := h.scheduler.Reload(s); err != nil {
+	if err := h.scheduler.ReloadWithDueChecks(s, h.containersLastRun, nil, nil); err != nil {
 		// Settings persisted but the scheduler could not re-register — report it.
 		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "error": scrubError(err)})
 		return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -362,5 +362,118 @@ func TestRuns(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Browse handler tests
+// ---------------------------------------------------------------------------
+
+// newBrowseRouter builds a minimal router whose HostMountRoot points to
+// the supplied temp dir, making it easy to test the browse handler in isolation.
+func newBrowseRouter(t *testing.T, mountRoot string) http.Handler {
+	t.Helper()
+	cfg := config.Config{AppKey: strings.Repeat("a", 64), DataDir: t.TempDir(), HostMountRoot: mountRoot}
+	st := newMemStore(t)
+	svc := api.NewService(cfg, st, &fakeServiceDocker{}, &fakeResticEngine{})
+	sched := schedule.New(func(string) error { return nil }, st.ListTargets)
+	h := api.NewHandler(cfg, st, &fakeServiceDocker{}, svc, sched, spike.DefaultProbes())
+	return h.Router()
+}
+
+func TestBrowseListsMountRoot(t *testing.T) {
+	root := t.TempDir()
+	// Create some subdirectories in the mount root.
+	for _, d := range []string{"appdata", "downloads", "media"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Also create a file (must NOT appear in results) and a hidden dir.
+	if err := os.WriteFile(filepath.Join(root, "readme.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".hidden"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newBrowseRouter(t, root)
+	w, m := doJSON(t, h, http.MethodGet, "/api/browse", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if m["ok"] != true {
+		t.Fatalf("expected ok:true, got %v", m)
+	}
+	dirsRaw, _ := m["dirs"].([]any)
+	names := make([]string, 0, len(dirsRaw))
+	for _, d := range dirsRaw {
+		dm, _ := d.(map[string]any)
+		names = append(names, dm["name"].(string))
+	}
+	// Should contain the three dirs but not the file or the hidden dir.
+	if len(names) != 3 {
+		t.Fatalf("expected 3 dirs, got %v", names)
+	}
+	for i, want := range []string{"appdata", "downloads", "media"} {
+		if names[i] != want {
+			t.Fatalf("dir[%d]: expected %q, got %q", i, want, names[i])
+		}
+	}
+}
+
+func TestBrowseListsSubpath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "appdata", "plex"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "appdata", "sonarr"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newBrowseRouter(t, root)
+	w, m := doJSON(t, h, http.MethodGet, "/api/browse?path=appdata", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	if m["ok"] != true {
+		t.Fatalf("expected ok:true, got %v", m)
+	}
+	dirsRaw, _ := m["dirs"].([]any)
+	if len(dirsRaw) != 2 {
+		t.Fatalf("expected 2 dirs under appdata, got %v", dirsRaw)
+	}
+	// paths must be relative to mount root.
+	first, _ := dirsRaw[0].(map[string]any)
+	if first["path"] != "appdata/plex" {
+		t.Fatalf("expected path 'appdata/plex', got %v", first["path"])
+	}
+}
+
+func TestBrowseRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	h := newBrowseRouter(t, root)
+
+	for _, bad := range []string{"../etc", "../../etc"} {
+		w, m := doJSON(t, h, http.MethodGet, "/api/browse?path="+bad, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected graceful 200 for %q, got %d", bad, w.Code)
+		}
+		if m["ok"] != false {
+			t.Fatalf("expected ok:false for traversal %q, got %v", bad, m)
+		}
+	}
+}
+
+func TestBrowseRejectsAbsolutePath(t *testing.T) {
+	root := t.TempDir()
+	h := newBrowseRouter(t, root)
+
+	w, m := doJSON(t, h, http.MethodGet, "/api/browse?path=%2Fetc", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected graceful 200, got %d", w.Code)
+	}
+	if m["ok"] != false {
+		t.Fatalf("expected ok:false for absolute path, got %v", m)
+	}
+}
+
 // ensure context import is used (Router handlers run under request context).
 var _ = context.Background

--- a/internal/dockercli/dockercli.go
+++ b/internal/dockercli/dockercli.go
@@ -58,12 +58,20 @@ func (c *Client) List(ctx context.Context) ([]ContainerInfo, error) {
 		if len(s.Names) > 0 {
 			name = normalizeName(s.Names[0])
 		}
+		ip := ""
+		for _, net := range s.NetworkSettings.Networks {
+			if net != nil && net.IPAddress != "" {
+				ip = net.IPAddress
+				break
+			}
+		}
 		out = append(out, ContainerInfo{
 			ID:     s.ID,
 			Name:   name,
 			Image:  s.Image,
 			State:  string(s.State),
 			Status: s.Status,
+			IP:     ip,
 		})
 	}
 	return out, nil

--- a/internal/dockercli/types.go
+++ b/internal/dockercli/types.go
@@ -14,6 +14,11 @@ type ContainerInfo struct {
 	Image  string
 	State  string
 	Status string
+	// IP is the first non-empty IP address found in the container's network
+	// settings. Empty when the container has no network (e.g. host networking
+	// configured without an explicit IP, or a stopped container whose network
+	// state is not stored in the list summary).
+	IP string
 }
 
 // Docker is the host-control surface consumed by the backup orchestrator.

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/robfig/cron/v3"
 
@@ -21,20 +22,40 @@ type BackupFunc func(containerName string) error
 // ListTargetsFunc returns the current list of targets.
 type ListTargetsFunc func() ([]store.Target, error)
 
-// ParseCadence converts a user-facing cadence string into a 5-field cron
-// expression. Recognised forms:
+// LastRunFunc returns the time of the last successful backup for a domain, or
+// a zero time when there has been none. It is injected so the schedule package
+// stays store-free (DI seam).
+type LastRunFunc func() (time.Time, error)
+
+// Cadence is the parsed result of a cadence string.
 //
-//   - "off"              → spec="", enabled=false
-//   - "daily HH:MM"      → "MM HH * * *",  enabled=true
-//   - "weekly DOW HH:MM" → "MM HH * * N",  enabled=true  (DOW = Sun–Sat)
-//   - raw 5-field cron   → passed through,  enabled=true
+//   - Enabled=false: the domain is off (Spec is empty, IntervalDays is 0).
+//   - Enabled=true, IntervalDays=0: a regular cron spec fires unconditionally.
+//   - Enabled=true, IntervalDays>0: the spec is a daily trigger (fires once per
+//     day at the given HH:MM) but the job must consult a due-check before
+//     doing any real work — only proceed if now − last-successful-run ≥ IntervalDays.
+type Cadence struct {
+	Spec         string // 5-field cron expression; empty when Enabled=false
+	Enabled      bool
+	IntervalDays int // >0 for everyN cadences only
+}
+
+// ParseCadence converts a user-facing cadence string into a Cadence.
+// Recognised forms:
+//
+//   - "off"                        → Cadence{Enabled:false}
+//   - "daily HH:MM"                → daily cron spec, unconditional
+//   - "weekly DOW[,DOW,...] HH:MM" → weekly on named days; DOW = Sun–Sat
+//     (single or comma-separated set, case-insensitive)
+//   - "everyN <N> HH:MM"           → daily cron spec + IntervalDays=N (N ≥ 1)
+//   - raw 5-field cron              → passed through unconditionally
 //
 // Any other input returns an error.
-func ParseCadence(s string) (spec string, enabled bool, err error) {
+func ParseCadence(s string) (Cadence, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		// Treat empty string as "off" — defensive against a settings PUT passing "".
-		return "", false, nil
+		// Treat empty string as "off" — defensive against settings PUT with "".
+		return Cadence{}, nil
 	}
 
 	parts := strings.Fields(s)
@@ -42,45 +63,65 @@ func ParseCadence(s string) (spec string, enabled bool, err error) {
 	switch parts[0] {
 	case "off":
 		if len(parts) != 1 {
-			return "", false, fmt.Errorf("schedule: unexpected tokens after 'off'")
+			return Cadence{}, fmt.Errorf("schedule: unexpected tokens after 'off'")
 		}
-		return "", false, nil
+		return Cadence{}, nil
 
 	case "daily":
 		if len(parts) != 2 {
-			return "", false, fmt.Errorf("schedule: 'daily' requires exactly one HH:MM argument")
+			return Cadence{}, fmt.Errorf("schedule: 'daily' requires exactly one HH:MM argument")
 		}
 		h, m, parseErr := parseHHMM(parts[1])
 		if parseErr != nil {
-			return "", false, fmt.Errorf("schedule: invalid time %q: %w", parts[1], parseErr)
+			return Cadence{}, fmt.Errorf("schedule: invalid time %q: %w", parts[1], parseErr)
 		}
-		return fmt.Sprintf("%d %d * * *", m, h), true, nil
+		return Cadence{Spec: fmt.Sprintf("%d %d * * *", m, h), Enabled: true}, nil
 
 	case "weekly":
+		// Accepts "weekly DOW HH:MM" or "weekly DOW,DOW,... HH:MM".
 		if len(parts) != 3 {
-			return "", false, fmt.Errorf("schedule: 'weekly' requires DOW and HH:MM arguments")
+			return Cadence{}, fmt.Errorf("schedule: 'weekly' requires DOW (or DOW,DOW,...) and HH:MM arguments")
 		}
-		dow, dowErr := parseDOW(parts[1])
+		dowSpec, dowErr := parseDOWSet(parts[1])
 		if dowErr != nil {
-			return "", false, fmt.Errorf("schedule: invalid day-of-week %q: %w", parts[1], dowErr)
+			return Cadence{}, fmt.Errorf("schedule: invalid day-of-week %q: %w", parts[1], dowErr)
 		}
 		h, m, parseErr := parseHHMM(parts[2])
 		if parseErr != nil {
-			return "", false, fmt.Errorf("schedule: invalid time %q: %w", parts[2], parseErr)
+			return Cadence{}, fmt.Errorf("schedule: invalid time %q: %w", parts[2], parseErr)
 		}
-		return fmt.Sprintf("%d %d * * %d", m, h, dow), true, nil
+		return Cadence{Spec: fmt.Sprintf("%d %d * * %s", m, h, dowSpec), Enabled: true}, nil
+
+	case "everyN":
+		// "everyN <N> HH:MM" — every N days at HH:MM.
+		if len(parts) != 3 {
+			return Cadence{}, fmt.Errorf("schedule: 'everyN' requires an integer N and HH:MM arguments")
+		}
+		n, parseErr := strconv.Atoi(parts[1])
+		if parseErr != nil || n < 1 {
+			return Cadence{}, fmt.Errorf("schedule: 'everyN' N must be a positive integer, got %q", parts[1])
+		}
+		h, m, parseErr := parseHHMM(parts[2])
+		if parseErr != nil {
+			return Cadence{}, fmt.Errorf("schedule: invalid time %q: %w", parts[2], parseErr)
+		}
+		return Cadence{
+			Spec:         fmt.Sprintf("%d %d * * *", m, h),
+			Enabled:      true,
+			IntervalDays: n,
+		}, nil
 
 	default:
 		// Accept a raw 5-field cron expression.
 		if len(parts) != 5 {
-			return "", false, fmt.Errorf("schedule: unrecognised cadence %q (expected 'off', 'daily HH:MM', 'weekly DOW HH:MM', or a 5-field cron)", s)
+			return Cadence{}, fmt.Errorf("schedule: unrecognised cadence %q (expected 'off', 'daily HH:MM', 'weekly DOW[,DOW,...] HH:MM', 'everyN N HH:MM', or a 5-field cron)", s)
 		}
 		// Validate it parses correctly.
 		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 		if _, parseErr := parser.Parse(s); parseErr != nil {
-			return "", false, fmt.Errorf("schedule: invalid cron expression %q: %w", s, parseErr)
+			return Cadence{}, fmt.Errorf("schedule: invalid cron expression %q: %w", s, parseErr)
 		}
-		return s, true, nil
+		return Cadence{Spec: s, Enabled: true}, nil
 	}
 }
 
@@ -107,6 +148,8 @@ var dowMap = map[string]int{
 	"Thu": 4, "Fri": 5, "Sat": 6,
 }
 
+// parseDOW parses a single day-of-week string (case-insensitive) and returns
+// its cron number.
 func parseDOW(s string) (int, error) {
 	// Normalize to title-case so "mon", "MON", "Mon" all work.
 	var normalized string
@@ -118,6 +161,35 @@ func parseDOW(s string) (int, error) {
 		return 0, fmt.Errorf("unknown day %q (expected Sun Mon Tue Wed Thu Fri Sat)", s)
 	}
 	return n, nil
+}
+
+// parseDOWSet parses a comma-separated list of day-of-week strings and returns
+// a cron-compatible DOW field string (e.g. "1,3,5" for Mon,Wed,Fri).
+// A single day is returned as just its number string (e.g. "1") for
+// backwards-compatibility with existing single-DOW weekly schedules.
+func parseDOWSet(s string) (string, error) {
+	tokens := strings.Split(s, ",")
+	nums := make([]string, 0, len(tokens))
+	seen := make(map[int]bool, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			return "", fmt.Errorf("empty day token in %q", s)
+		}
+		n, err := parseDOW(tok)
+		if err != nil {
+			return "", err
+		}
+		if seen[n] {
+			return "", fmt.Errorf("duplicate day %q in %q", tok, s)
+		}
+		seen[n] = true
+		nums = append(nums, strconv.Itoa(n))
+	}
+	if len(nums) == 0 {
+		return "", fmt.Errorf("no days specified in %q", s)
+	}
+	return strings.Join(nums, ","), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -155,10 +227,33 @@ func (s *Scheduler) Stop() {
 	<-ctx.Done()
 }
 
+// domainSpec bundles everything needed to register one scheduler domain entry.
+type domainSpec struct {
+	cadence string
+	name    string
+	fn      func()
+	lastRun LastRunFunc // nil for domains without everyN support
+}
+
 // Reload re-reads the schedule settings and re-registers all domain entries.
 // It removes any previously registered entries first, so it is safe to call
 // repeatedly (e.g. after a settings change).
+//
+// For everyN domains the lastRunFn is consulted when the daily trigger fires;
+// the job is a no-op when now − lastRun < IntervalDays. Pass nil for lastRunFn
+// to disable the due-gate (used when a domain does not yet have a backing store
+// query, e.g. VMs / flash in Phase 1).
 func (s *Scheduler) Reload(settings store.Settings) error {
+	return s.ReloadWithDueChecks(settings, nil, nil, nil)
+}
+
+// ReloadWithDueChecks is the full-fidelity Reload that accepts per-domain
+// last-run queries so the everyN due-gate is enforced. Pass nil for any domain
+// that does not need the gate (it is then equivalent to a plain daily trigger).
+func (s *Scheduler) ReloadWithDueChecks(
+	settings store.Settings,
+	containersLastRun, vmsLastRun, flashLastRun LastRunFunc,
+) error {
 	// Remove all existing entries.
 	for _, id := range s.entryIDs {
 		s.c.Remove(id)
@@ -166,11 +261,7 @@ func (s *Scheduler) Reload(settings store.Settings) error {
 	s.entryIDs = s.entryIDs[:0]
 
 	// Register enabled domains.
-	domains := []struct {
-		cadence string
-		name    string
-		fn      func()
-	}{
+	domains := []domainSpec{
 		{
 			cadence: settings.ContainersSchedule,
 			name:    "containers",
@@ -182,31 +273,57 @@ func (s *Scheduler) Reload(settings store.Settings) error {
 				}
 				RunContainersJob(targets, s.backup)
 			},
+			lastRun: containersLastRun,
 		},
 		// VMs and Flash cadences are stored but their jobs are no-ops in Phase 1.
 		{
 			cadence: settings.VMsSchedule,
 			name:    "vms",
 			fn:      func() { log.Print("schedule: vms job: not yet implemented in Phase 1") },
+			lastRun: vmsLastRun,
 		},
 		{
 			cadence: settings.FlashSchedule,
 			name:    "flash",
 			fn:      func() { log.Print("schedule: flash job: not yet implemented in Phase 1") },
+			lastRun: flashLastRun,
 		},
 	}
 
 	for _, d := range domains {
-		spec, enabled, err := ParseCadence(d.cadence)
+		cad, err := ParseCadence(d.cadence)
 		if err != nil {
 			return fmt.Errorf("schedule: domain %s: %w", d.name, err)
 		}
-		if !enabled {
+		if !cad.Enabled {
 			continue
 		}
+
 		domainName := d.name
 		jobFn := d.fn
-		id, err := s.c.AddFunc(spec, func() {
+
+		// For everyN cadences wrap the job with the due-check so the daily
+		// trigger does nothing when the interval has not elapsed yet.
+		if cad.IntervalDays > 0 && d.lastRun != nil {
+			innerFn := jobFn
+			intervalDays := cad.IntervalDays
+			lastRunFn := d.lastRun
+			jobFn = func() {
+				last, err := lastRunFn()
+				if err != nil {
+					log.Printf("schedule: %s everyN due-check: last-run query failed: %v", domainName, err)
+					return
+				}
+				minAge := time.Duration(intervalDays) * 24 * time.Hour
+				if !last.IsZero() && time.Since(last) < minAge {
+					log.Printf("schedule: %s everyN skipped — last run %v ago, interval %d days", domainName, time.Since(last).Round(time.Second), intervalDays)
+					return
+				}
+				innerFn()
+			}
+		}
+
+		id, err := s.c.AddFunc(cad.Spec, func() {
 			log.Printf("schedule: running %s job", domainName)
 			jobFn()
 		})

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -15,41 +15,44 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestParseCadenceOff(t *testing.T) {
-	spec, enabled, err := schedule.ParseCadence("off")
+	cad, err := schedule.ParseCadence("off")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if enabled {
+	if cad.Enabled {
 		t.Fatal("'off' must be disabled")
 	}
-	if spec != "" {
-		t.Fatalf("spec for 'off' must be empty, got %q", spec)
+	if cad.Spec != "" {
+		t.Fatalf("spec for 'off' must be empty, got %q", cad.Spec)
 	}
 }
 
 func TestParseCadenceDaily(t *testing.T) {
-	spec, enabled, err := schedule.ParseCadence("daily 02:30")
+	cad, err := schedule.ParseCadence("daily 02:30")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !enabled {
+	if !cad.Enabled {
 		t.Fatal("daily must be enabled")
 	}
-	if spec != "30 2 * * *" {
-		t.Fatalf("expected '30 2 * * *', got %q", spec)
+	if cad.Spec != "30 2 * * *" {
+		t.Fatalf("expected '30 2 * * *', got %q", cad.Spec)
+	}
+	if cad.IntervalDays != 0 {
+		t.Fatalf("daily must have IntervalDays=0, got %d", cad.IntervalDays)
 	}
 }
 
 func TestParseCadenceWeekly(t *testing.T) {
-	spec, enabled, err := schedule.ParseCadence("weekly Mon 03:00")
+	cad, err := schedule.ParseCadence("weekly Mon 03:00")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !enabled {
+	if !cad.Enabled {
 		t.Fatal("weekly must be enabled")
 	}
-	if spec != "0 3 * * 1" {
-		t.Fatalf("expected '0 3 * * 1', got %q", spec)
+	if cad.Spec != "0 3 * * 1" {
+		t.Fatalf("expected '0 3 * * 1', got %q", cad.Spec)
 	}
 }
 
@@ -67,60 +70,123 @@ func TestParseCadenceWeeklyAllDays(t *testing.T) {
 		{"Sat", "6"},
 	}
 	for _, c := range cases {
-		spec, enabled, err := schedule.ParseCadence("weekly " + c.day + " 00:00")
+		cad, err := schedule.ParseCadence("weekly " + c.day + " 00:00")
 		if err != nil {
 			t.Fatalf("day %s: unexpected error: %v", c.day, err)
 		}
-		if !enabled {
+		if !cad.Enabled {
 			t.Fatalf("day %s: must be enabled", c.day)
 		}
 		want := "0 0 * * " + c.want
-		if spec != want {
-			t.Fatalf("day %s: expected %q, got %q", c.day, want, spec)
+		if cad.Spec != want {
+			t.Fatalf("day %s: expected %q, got %q", c.day, want, cad.Spec)
 		}
+	}
+}
+
+// TestParseCadenceWeeklyMultiDOW verifies comma-separated weekday sets.
+func TestParseCadenceWeeklyMultiDOW(t *testing.T) {
+	cad, err := schedule.ParseCadence("weekly Mon,Wed,Fri 02:30")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cad.Enabled {
+		t.Fatal("must be enabled")
+	}
+	if cad.Spec != "30 2 * * 1,3,5" {
+		t.Fatalf("expected '30 2 * * 1,3,5', got %q", cad.Spec)
+	}
+}
+
+// TestParseCadenceWeeklyMultiDOWCaseInsensitive verifies mixed-case multi-DOW.
+func TestParseCadenceWeeklyMultiDOWCaseInsensitive(t *testing.T) {
+	cad, err := schedule.ParseCadence("weekly mon,WED,fri 00:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cad.Spec != "0 0 * * 1,3,5" {
+		t.Fatalf("expected '0 0 * * 1,3,5', got %q", cad.Spec)
+	}
+}
+
+// TestParseCadenceWeeklyDuplicateDOW ensures duplicate days are rejected.
+func TestParseCadenceWeeklyDuplicateDOW(t *testing.T) {
+	_, err := schedule.ParseCadence("weekly Mon,Mon 03:00")
+	if err == nil {
+		t.Fatal("expected error for duplicate day")
 	}
 }
 
 func TestParseCadenceRawCron(t *testing.T) {
 	raw := "15 4 * * 2"
-	spec, enabled, err := schedule.ParseCadence(raw)
+	cad, err := schedule.ParseCadence(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !enabled {
+	if !cad.Enabled {
 		t.Fatal("raw cron must be enabled")
 	}
-	if spec != raw {
-		t.Fatalf("raw cron must pass through unchanged, got %q", spec)
+	if cad.Spec != raw {
+		t.Fatalf("raw cron must pass through unchanged, got %q", cad.Spec)
 	}
 }
 
 func TestParseCadenceEmptyIsOff(t *testing.T) {
-	spec, enabled, err := schedule.ParseCadence("")
+	cad, err := schedule.ParseCadence("")
 	if err != nil {
 		t.Fatalf("empty cadence must not error, got: %v", err)
 	}
-	if enabled {
+	if cad.Enabled {
 		t.Fatal("empty cadence must be disabled")
 	}
-	if spec != "" {
-		t.Fatalf("empty cadence spec must be empty, got %q", spec)
+	if cad.Spec != "" {
+		t.Fatalf("empty cadence spec must be empty, got %q", cad.Spec)
 	}
 }
 
 func TestParseCadenceWeeklyCaseInsensitive(t *testing.T) {
 	cases := []string{"mon", "MON", "Mon"}
 	for _, dow := range cases {
-		spec, enabled, err := schedule.ParseCadence("weekly " + dow + " 03:00")
+		cad, err := schedule.ParseCadence("weekly " + dow + " 03:00")
 		if err != nil {
 			t.Fatalf("DOW %q: unexpected error: %v", dow, err)
 		}
-		if !enabled {
+		if !cad.Enabled {
 			t.Fatalf("DOW %q: must be enabled", dow)
 		}
-		if spec != "0 3 * * 1" {
-			t.Fatalf("DOW %q: expected '0 3 * * 1', got %q", dow, spec)
+		if cad.Spec != "0 3 * * 1" {
+			t.Fatalf("DOW %q: expected '0 3 * * 1', got %q", dow, cad.Spec)
 		}
+	}
+}
+
+// TestParseCadenceEveryN verifies basic everyN parsing and that IntervalDays
+// is populated.
+func TestParseCadenceEveryN(t *testing.T) {
+	cad, err := schedule.ParseCadence("everyN 5 03:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cad.Enabled {
+		t.Fatal("everyN must be enabled")
+	}
+	if cad.Spec != "0 3 * * *" {
+		t.Fatalf("expected '0 3 * * *', got %q", cad.Spec)
+	}
+	if cad.IntervalDays != 5 {
+		t.Fatalf("expected IntervalDays=5, got %d", cad.IntervalDays)
+	}
+}
+
+// TestParseCadenceEveryNOne verifies that N=1 is valid (effectively daily with
+// the due-gate, which always fires).
+func TestParseCadenceEveryNOne(t *testing.T) {
+	cad, err := schedule.ParseCadence("everyN 1 00:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cad.IntervalDays != 1 {
+		t.Fatalf("expected IntervalDays=1, got %d", cad.IntervalDays)
 	}
 }
 
@@ -133,12 +199,112 @@ func TestParseCadenceInvalid(t *testing.T) {
 		"weekly Mon",
 		"weekly Xyz 03:00",
 		"not a cron at all extra words here",
+		"everyN",
+		"everyN 0 03:00",   // N must be ≥ 1
+		"everyN -1 03:00",  // negative not allowed
+		"everyN abc 03:00", // non-integer
+		"everyN 5",         // missing time
 	}
 	for _, s := range cases {
-		_, _, err := schedule.ParseCadence(s)
+		_, err := schedule.ParseCadence(s)
 		if err == nil {
 			t.Fatalf("expected error for %q", s)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// everyN due-gate logic tests
+// ---------------------------------------------------------------------------
+
+// TestEveryNDueGateSkipsWhenTooSoon verifies the injected lastRun check
+// suppresses the job when the interval has not elapsed.
+func TestEveryNDueGateSkipsWhenTooSoon(t *testing.T) {
+	var ran bool
+
+	// last run was only 1 hour ago; interval = 5 days → must NOT fire.
+	lastRun := func() (time.Time, error) {
+		return time.Now().Add(-1 * time.Hour), nil
+	}
+
+	jobFn := func() { ran = true }
+	gate := buildEveryNGate(5, lastRun, jobFn)
+	gate()
+
+	if ran {
+		t.Fatal("expected job to be skipped (interval not elapsed)")
+	}
+}
+
+// TestEveryNDueGateFiresWhenDue verifies the gate lets the job through when
+// the interval has elapsed.
+func TestEveryNDueGateFiresWhenDue(t *testing.T) {
+	var ran bool
+
+	// last run was 6 days ago; interval = 5 days → must fire.
+	lastRun := func() (time.Time, error) {
+		return time.Now().Add(-6 * 24 * time.Hour), nil
+	}
+
+	jobFn := func() { ran = true }
+	gate := buildEveryNGate(5, lastRun, jobFn)
+	gate()
+
+	if !ran {
+		t.Fatal("expected job to run (interval elapsed)")
+	}
+}
+
+// TestEveryNDueGateFiresWhenNeverRun verifies that a zero lastRun (no prior
+// run) always lets the job through.
+func TestEveryNDueGateFiresWhenNeverRun(t *testing.T) {
+	var ran bool
+
+	lastRun := func() (time.Time, error) {
+		return time.Time{}, nil // zero → never run
+	}
+
+	jobFn := func() { ran = true }
+	gate := buildEveryNGate(30, lastRun, jobFn)
+	gate()
+
+	if !ran {
+		t.Fatal("expected job to run (never run before)")
+	}
+}
+
+// TestEveryNDueGateSkipsOnLastRunError ensures the gate is conservative —
+// when the due-check query fails it skips the job rather than running it.
+func TestEveryNDueGateSkipsOnLastRunError(t *testing.T) {
+	var ran bool
+
+	lastRun := func() (time.Time, error) {
+		return time.Time{}, errors.New("db unavailable")
+	}
+
+	jobFn := func() { ran = true }
+	gate := buildEveryNGate(5, lastRun, jobFn)
+	gate()
+
+	if ran {
+		t.Fatal("expected job to be skipped when lastRun query errors")
+	}
+}
+
+// buildEveryNGate is a test helper that constructs the everyN due-gate closure
+// in the same way the Scheduler does, so the logic can be tested without
+// spinning up a real cron runner.
+func buildEveryNGate(intervalDays int, lastRunFn schedule.LastRunFunc, jobFn func()) func() {
+	return func() {
+		last, err := lastRunFn()
+		if err != nil {
+			return // conservative: skip on error
+		}
+		minAge := time.Duration(intervalDays) * 24 * time.Hour
+		if !last.IsZero() && time.Since(last) < minAge {
+			return // not due yet
+		}
+		jobFn()
 	}
 }
 
@@ -230,6 +396,49 @@ func TestSchedulerReloadRegistersEnabledDomains(t *testing.T) {
 		t.Fatalf("second Reload returned error: %v", err)
 	}
 
+	sched.Stop()
+}
+
+// TestSchedulerReloadEveryN verifies that an everyN schedule reloads without
+// error and that the Cadence is correctly parsed.
+func TestSchedulerReloadEveryN(t *testing.T) {
+	backupFn := func(_ string) error { return nil }
+	listFn := func() ([]store.Target, error) { return nil, nil }
+
+	sched := schedule.New(backupFn, listFn)
+
+	settings := store.Settings{
+		ContainersSchedule: "everyN 7 04:00",
+		VMsSchedule:        "off",
+		FlashSchedule:      "off",
+	}
+	if err := sched.Reload(settings); err != nil {
+		t.Fatalf("Reload with everyN returned error: %v", err)
+	}
+	sched.Stop()
+}
+
+// TestSchedulerReloadWithDueChecksEveryNFires verifies ReloadWithDueChecks
+// wires the due-gate so a containers job is not triggered when the interval has
+// not elapsed (we confirm the gate by using a lastRun that is only 1h ago with
+// a 5-day interval, then manually calling RunContainersJob to confirm the cron
+// job itself is the only backed-up path — we can't trigger the cron tick here,
+// but we verify Reload doesn't error).
+func TestSchedulerReloadWithDueChecksEveryNFires(t *testing.T) {
+	backupFn := func(_ string) error { return nil }
+	listFn := func() ([]store.Target, error) { return nil, nil }
+	lastRun := func() (time.Time, error) { return time.Now().Add(-6 * 24 * time.Hour), nil }
+
+	sched := schedule.New(backupFn, listFn)
+
+	settings := store.Settings{
+		ContainersSchedule: "everyN 5 03:00",
+		VMsSchedule:        "off",
+		FlashSchedule:      "off",
+	}
+	if err := sched.ReloadWithDueChecks(settings, lastRun, nil, nil); err != nil {
+		t.Fatalf("ReloadWithDueChecks returned error: %v", err)
+	}
 	sched.Stop()
 }
 

--- a/internal/store/runs.go
+++ b/internal/store/runs.go
@@ -76,6 +76,30 @@ func (r *Repo) LastSuccessfulBackup(targetID string) (*Run, error) {
 	return &run, nil
 }
 
+// LastSuccessfulContainerBackup returns the time of the most recent successful
+// backup run across ALL container targets, or a zero time when there has been
+// none. This is used by the scheduler's everyN due-gate to decide whether the
+// containers domain is due for a run.
+func (r *Repo) LastSuccessfulContainerBackup() (time.Time, error) {
+	row := r.db.QueryRow(`
+		SELECT finished_at
+		FROM runs
+		WHERE kind = 'backup' AND status = 'success'
+		ORDER BY started_at DESC
+		LIMIT 1`)
+	var ts sql.NullInt64
+	if err := row.Scan(&ts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("LastSuccessfulContainerBackup: %w", err)
+	}
+	if !ts.Valid {
+		return time.Time{}, nil
+	}
+	return time.Unix(ts.Int64, 0), nil
+}
+
 // ListRuns returns up to limit recent runs across all targets, newest first.
 func (r *Repo) ListRuns(limit int) ([]Run, error) {
 	rows, err := r.db.Query(`

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bombvault-ui",
       "version": "0.0.0",
       "dependencies": {
+        "flag-icons": "^7.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1"
@@ -1751,6 +1752,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "flag-icons": "^7.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"

--- a/web/src/app/Layout.tsx
+++ b/web/src/app/Layout.tsx
@@ -1,12 +1,10 @@
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "../components/Sidebar";
 import { TopBar } from "../components/TopBar";
-import { useT } from "../lib/i18n";
 import { useEffect, useState } from "react";
 import { getSettings, type Settings } from "../lib/api";
 
 export function Layout() {
-  const { t, lang, setLanguage, supportedLangs, langNames } = useT();
   const [settings, setSettings] = useState<Settings | null>(null);
 
   // Load settings once on mount to drive sidebar feature flags (vmsEnabled etc.)
@@ -22,15 +20,9 @@ export function Layout() {
 
   return (
     <div className="flex h-screen overflow-hidden bg-carbon-background">
-      <Sidebar t={t} settings={settings} />
+      <Sidebar settings={settings} />
       <div className="flex flex-col flex-1 overflow-hidden min-w-0">
-        <TopBar
-          t={t}
-          lang={lang}
-          setLanguage={setLanguage}
-          supportedLangs={supportedLangs}
-          langNames={langNames}
-        />
+        <TopBar />
         <main className="flex-1 overflow-y-auto p-6">
           <Outlet />
         </main>

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -3,19 +3,22 @@ import { Layout } from "./Layout";
 import { Dashboard } from "../pages/Dashboard";
 import { Containers } from "../pages/Containers";
 import { SettingsPage } from "../pages/Settings";
+import { I18nProvider } from "../lib/i18n";
 
 export function AppRouter() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/containers" element={<Containers />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <I18nProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route index element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/containers" element={<Containers />} />
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </I18nProvider>
   );
 }

--- a/web/src/components/IncludeToggle.tsx
+++ b/web/src/components/IncludeToggle.tsx
@@ -44,7 +44,7 @@ export function IncludeToggle({ name, initial }: IncludeToggleProps) {
         }`}
       >
         <span
-          className={`inline-block h-3.5 w-3.5 rounded-full bg-[#161616] transition-transform ${
+          className={`inline-block h-3.5 w-3.5 rounded-full bg-carbon-background transition-transform ${
             enabled ? "translate-x-[18px]" : "translate-x-[3px]"
           }`}
         />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -116,10 +116,10 @@ export function Sidebar({ settings }: SidebarProps) {
     <aside className="flex flex-col w-56 shrink-0 h-full bg-carbon-surface border-r border-carbon-border">
       {/* Logo / brand */}
       <div className="flex items-center gap-2.5 px-4 py-5 border-b border-carbon-border">
-        <div className="w-7 h-7 rounded-lg bg-carbon-surface3 flex items-center justify-center">
+        <div className="w-7 h-7 rounded-lg bg-carbon-surface3 text-carbon-text flex items-center justify-center">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="5" stroke="#f4f4f4" strokeWidth="1.5" />
-            <path d="M8 5v3l2 1.5" stroke="#f4f4f4" strokeWidth="1.3" strokeLinecap="round" />
+            <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M8 5v3l2 1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
           </svg>
         </div>
         <span className="text-carbon-text font-semibold text-sm tracking-wide">

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,11 +1,8 @@
 import { NavLink } from "react-router-dom";
 import type { Settings } from "../lib/api";
-import type { useT } from "../lib/i18n";
-
-type T = ReturnType<typeof useT>["t"];
+import { useT } from "../lib/i18n";
 
 interface SidebarProps {
-  t: T;
   settings: Settings | null;
 }
 
@@ -110,7 +107,8 @@ function NavItem({ to, label, icon, disabled, comingSoon }: NavItem) {
   );
 }
 
-export function Sidebar({ t, settings }: SidebarProps) {
+export function Sidebar({ settings }: SidebarProps) {
+  const { t } = useT();
   const vmsEnabled = settings?.vmsEnabled ?? false;
   const flashEnabled = settings?.flashEnabled ?? false;
 

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,17 +1,10 @@
 import { getTheme, toggleTheme } from "../lib/theme";
-import { useState } from "react";
-import type { useT } from "../lib/i18n";
+import { useState, useRef, useEffect } from "react";
+import { useT } from "../lib/i18n";
 
-type T = ReturnType<typeof useT>["t"];
-type LangCode = "en" | "de";
-
-interface TopBarProps {
-  t: T;
-  lang: LangCode;
-  setLanguage: (code: LangCode) => void;
-  supportedLangs: LangCode[];
-  langNames: Record<LangCode, string>;
-}
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
 
 function IconSun() {
   return (
@@ -40,13 +33,115 @@ function IconMoon() {
   );
 }
 
-export function TopBar({
-  t,
-  lang,
-  setLanguage,
-  supportedLangs,
-  langNames,
-}: TopBarProps) {
+// ---------------------------------------------------------------------------
+// Flag helper — renders a flag-icons span for the given ISO 3166-1 alpha-2 code
+// ---------------------------------------------------------------------------
+
+function Flag({ code }: { code: string }) {
+  return (
+    <span
+      className={`fi fi-${code}`}
+      style={{ width: "1.25em", height: "1em", display: "inline-block", flexShrink: 0 }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LanguageSwitcher
+// ---------------------------------------------------------------------------
+
+function LanguageSwitcher() {
+  const { lang, setLanguage, languages, t } = useT();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const current = languages.find((l) => l.code === lang) ?? languages[0];
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      {/* Trigger button — shows current flag + label */}
+      <button
+        aria-label={t("language.label")}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-carbon-textSub border border-carbon-border bg-carbon-surface hover:bg-carbon-hover hover:text-carbon-text transition-colors"
+      >
+        <Flag code={current.flag} />
+        <span className="hidden sm:inline">{current.label}</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          className={`transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        >
+          <path d="M2 3.5l3 3 3-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div
+          role="listbox"
+          aria-label={t("language.label")}
+          className="absolute right-0 top-full mt-1 z-50 w-48 max-h-72 overflow-y-auto rounded-xl border border-carbon-border bg-carbon-surface shadow-lg"
+          style={{ scrollbarColor: "var(--carbon-border) transparent" }}
+        >
+          {languages.map((l) => (
+            <button
+              key={l.code}
+              role="option"
+              aria-selected={l.code === lang}
+              onClick={() => {
+                setLanguage(l.code);
+                setOpen(false);
+              }}
+              className={`flex items-center gap-2.5 w-full px-3 py-2 text-sm text-left transition-colors ${
+                l.code === lang
+                  ? "bg-carbon-surface3 text-carbon-text"
+                  : "text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text"
+              }`}
+            >
+              <Flag code={l.flag} />
+              <span>{l.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TopBar
+// ---------------------------------------------------------------------------
+
+export function TopBar() {
+  const { t } = useT();
   const [theme, setThemeState] = useState(getTheme);
 
   function handleToggleTheme() {
@@ -56,26 +151,8 @@ export function TopBar({
 
   return (
     <header className="flex items-center justify-end gap-2 px-4 py-2.5 bg-carbon-surface border-b border-carbon-border shrink-0">
-      {/* Language switcher */}
-      <div className="flex items-center gap-1">
-        <span className="text-xs text-carbon-textMuted mr-1">{t("language.label")}:</span>
-        <div className="flex rounded-lg overflow-hidden border border-carbon-border">
-          {supportedLangs.map((code) => (
-            <button
-              key={code}
-              onClick={() => setLanguage(code)}
-              className={`px-2 py-1 text-xs font-medium transition-colors ${
-                lang === code
-                  ? "bg-carbon-surface3 text-carbon-text"
-                  : "bg-carbon-surface text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text"
-              }`}
-              title={langNames[code]}
-            >
-              {langNames[code]}
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* Flag-based language switcher */}
+      <LanguageSwitcher />
 
       {/* Theme toggle */}
       <button

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,25 +2,48 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+/* ---------------------------------------------------------------------------
+   Carbon palette as CSS custom properties.
+   Dark is default; [data-theme="light"] overrides to an IBM Carbon light theme.
+   Tailwind's carbon-* tokens reference these vars so toggling data-theme
+   immediately re-colours the entire app.
+   --------------------------------------------------------------------------- */
+
+:root,
+[data-theme="dark"] {
   color-scheme: dark;
+
+  --carbon-bg:        #161616;
+  --carbon-surface:   #262626;
+  --carbon-surface2:  #393939;
+  --carbon-surface3:  #525252;
+  --carbon-text:      #f4f4f4;
+  --carbon-text-sub:  #c6c6c6;
+  --carbon-text-muted:#8d8d8d;
+  --carbon-border:    #393939;
+  --carbon-hover:     #353535;
 }
 
 [data-theme="light"] {
   color-scheme: light;
+
+  --carbon-bg:        #ffffff;
+  --carbon-surface:   #f4f4f4;
+  --carbon-surface2:  #e0e0e0;
+  --carbon-surface3:  #c6c6c6;
+  --carbon-text:      #161616;
+  --carbon-text-sub:  #393939;
+  --carbon-text-muted:#6f6f6f;
+  --carbon-border:    #e0e0e0;
+  --carbon-hover:     #e8e8e8;
 }
 
 body {
   margin: 0;
-  background-color: #161616;
-  color: #f4f4f4;
+  background-color: var(--carbon-bg);
+  color: var(--carbon-text);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
-}
-
-[data-theme="light"] body {
-  background-color: #f4f4f4;
-  color: #161616;
 }
 
 * {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,8 @@ export interface Container {
   image: string;
   state: string;
   status: string;
+  /** First non-empty IP from the container's network settings. Empty string when none. */
+  ip: string;
   includeInSchedule: boolean;
   lastBackup: number | null;
 }
@@ -95,6 +97,24 @@ export interface SpikeResponse {
   ok: boolean;
   allOk: boolean;
   checks: SpikeCheck[];
+}
+
+/** A single subdirectory entry from GET /api/browse */
+export interface BrowseDirEntry {
+  name: string;
+  /** Relative path from HostMountRoot, e.g. "appdata/plex" */
+  path: string;
+}
+
+/** Response from GET /api/browse?path=<subpath> */
+export interface BrowseResponse {
+  ok: boolean;
+  /** The server's HostMountRoot (absolute path inside the container). */
+  root?: string;
+  /** The subpath that was listed (mirrors the ?path= query parameter). */
+  path?: string;
+  dirs?: BrowseDirEntry[];
+  error?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,4 +208,13 @@ export function runSpike(): Promise<SpikeResponse> {
 
 export function listRuns(): Promise<ListRunsResponse> {
   return fetchJSON("/api/runs");
+}
+
+/**
+ * Lists the immediate subdirectories of <HostMountRoot>/<path>.
+ * Pass an empty string (or omit) to list the mount root itself.
+ */
+export function browse(path: string = ""): Promise<BrowseResponse> {
+  const qs = path ? `?path=${encodeURIComponent(path)}` : "";
+  return fetchJSON(`/api/browse${qs}`);
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1,12 +1,13 @@
 // ---------------------------------------------------------------------------
-// Minimal i18n — en + de; other locales stub to English.
-// useT() returns a translation function. Language state is in localStorage.
+// i18n — React Context-based, 26 locales, flag switcher support
 // ---------------------------------------------------------------------------
 
-import { useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
 
 // ---------------------------------------------------------------------------
-// Locale strings — en is the source of truth
+// Translation key set — en is the source of truth
 // ---------------------------------------------------------------------------
 
 const en = {
@@ -119,11 +120,11 @@ const en = {
   "settings.error": "Error saving settings",
 } as const;
 
-type TranslationKey = keyof typeof en;
+export type TranslationKey = keyof typeof en;
 type Translations = Record<TranslationKey, string>;
 
 // ---------------------------------------------------------------------------
-// German locale
+// German locale (full)
 // ---------------------------------------------------------------------------
 
 const de: Translations = {
@@ -228,66 +229,129 @@ const de: Translations = {
 };
 
 // ---------------------------------------------------------------------------
-// Locale registry
+// Locale registry — 26 languages. Only en + de are fully translated;
+// all others stub to English (full translations are a separate backlog item).
 // ---------------------------------------------------------------------------
 
-type LangCode = "en" | "de";
-
-const locales: Record<LangCode, Translations> = { en, de };
-
-const SUPPORTED_LANGS: LangCode[] = ["en", "de"];
-const LANG_NAMES: Record<LangCode, string> = { en: "English", de: "Deutsch" };
-const STORAGE_KEY = "bv-lang";
-const DEFAULT_LANG: LangCode = "en";
-
-function resolveCode(raw: string | null): LangCode {
-  if (raw === "en" || raw === "de") return raw;
-  const browser = navigator.language.slice(0, 2);
-  if (browser === "en" || browser === "de") return browser;
-  return DEFAULT_LANG;
+export interface Language {
+  /** BCP-47 language code used as the locale key. */
+  code: string;
+  /** Endonym — the language's own name, shown in the picker. */
+  label: string;
+  /** ISO 3166-1 alpha-2 region code used by flag-icons (fi fi-XX). */
+  flag: string;
+  /** true for right-to-left languages (Arabic, Hebrew, …). */
+  rtl?: boolean;
 }
 
-function getLang(): LangCode {
+export const LANGUAGES: Language[] = [
+  { code: "en", label: "English",      flag: "gb" },
+  { code: "de", label: "Deutsch",      flag: "de" },
+  { code: "fr", label: "Français",     flag: "fr" },
+  { code: "es", label: "Español",      flag: "es" },
+  { code: "it", label: "Italiano",     flag: "it" },
+  { code: "pt", label: "Português",    flag: "pt" },
+  { code: "nl", label: "Nederlands",   flag: "nl" },
+  { code: "pl", label: "Polski",       flag: "pl" },
+  { code: "ru", label: "Русский",      flag: "ru" },
+  { code: "uk", label: "Українська",   flag: "ua" },
+  { code: "cs", label: "Čeština",      flag: "cz" },
+  { code: "sv", label: "Svenska",      flag: "se" },
+  { code: "da", label: "Dansk",        flag: "dk" },
+  { code: "fi", label: "Suomi",        flag: "fi" },
+  { code: "no", label: "Norsk",        flag: "no" },
+  { code: "tr", label: "Türkçe",       flag: "tr" },
+  { code: "el", label: "Ελληνικά",     flag: "gr" },
+  { code: "hu", label: "Magyar",       flag: "hu" },
+  { code: "ro", label: "Română",       flag: "ro" },
+  { code: "ja", label: "日本語",        flag: "jp" },
+  { code: "ko", label: "한국어",        flag: "kr" },
+  { code: "zh", label: "中文",          flag: "cn" },
+  { code: "ar", label: "العربية",       flag: "sa", rtl: true },
+  { code: "he", label: "עברית",         flag: "il", rtl: true },
+  { code: "th", label: "ไทย",           flag: "th" },
+  { code: "vi", label: "Tiếng Việt",   flag: "vn" },
+];
+
+export const SUPPORTED = LANGUAGES.map((l) => l.code);
+const DEFAULT_CODE = "en";
+const STORAGE_KEY = "bv-lang";
+
+/** Whether a language code is right-to-left. */
+export const isRtl = (code: string): boolean =>
+  LANGUAGES.find((l) => l.code === code)?.rtl ?? false;
+
+// Fully translated locales — all others fall back to English at runtime.
+const locales: Record<string, Translations> = { en, de };
+
+function resolveCode(raw: string | null): string {
+  if (raw && SUPPORTED.includes(raw)) return raw;
+  const browser = navigator.language.slice(0, 2);
+  if (SUPPORTED.includes(browser)) return browser;
+  return DEFAULT_CODE;
+}
+
+function storedCode(): string {
   return resolveCode(localStorage.getItem(STORAGE_KEY));
 }
 
-function setLang(code: LangCode): void {
-  localStorage.setItem(STORAGE_KEY, code);
-}
-
-/** Called at boot in main.tsx. */
+/** Called at boot in main.tsx before first React render (flash prevention). */
 export function applyStoredLanguage(): void {
-  const code = getLang();
+  const code = storedCode();
   document.documentElement.setAttribute("lang", code);
+  if (isRtl(code)) document.documentElement.setAttribute("dir", "rtl");
 }
 
 // ---------------------------------------------------------------------------
-// useT() hook
+// React Context
 // ---------------------------------------------------------------------------
 
-/** Returns [t, currentLang, setLanguage, supportedLangs, langNames]. */
-export function useT(): {
+export interface I18nContextValue {
+  lang: string;
+  setLanguage: (code: string) => void;
   t: (key: TranslationKey) => string;
-  lang: LangCode;
-  setLanguage: (code: LangCode) => void;
-  supportedLangs: LangCode[];
-  langNames: Record<LangCode, string>;
-} {
-  const [lang, setLangState] = useState<LangCode>(getLang);
+  languages: Language[];
+}
 
-  const setLanguage = useCallback((code: LangCode) => {
-    setLang(code);
+// Provide a safe default so `useT()` never throws outside a Provider during tests.
+const I18nContext = createContext<I18nContextValue>({
+  lang: DEFAULT_CODE,
+  setLanguage: () => undefined,
+  t: (key) => en[key] ?? key,
+  languages: LANGUAGES,
+});
+
+/** Mount once at the app root (Layout or main). Children share one language state. */
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [lang, setLangState] = useState<string>(storedCode);
+
+  const setLanguage = useCallback((code: string) => {
+    if (!SUPPORTED.includes(code)) return;
+    localStorage.setItem(STORAGE_KEY, code);
     document.documentElement.setAttribute("lang", code);
+    document.documentElement.setAttribute("dir", isRtl(code) ? "rtl" : "ltr");
     setLangState(code);
   }, []);
 
   const t = useCallback(
     (key: TranslationKey): string => {
-      const locale = locales[lang] ?? locales[DEFAULT_LANG];
+      const locale = locales[lang] ?? locales[DEFAULT_CODE];
       return locale[key] ?? en[key] ?? key;
     },
     [lang]
   );
 
-  return { t, lang, setLanguage, supportedLangs: SUPPORTED_LANGS, langNames: LANG_NAMES };
+  return createElement(
+    I18nContext.Provider,
+    { value: { lang, setLanguage, t, languages: LANGUAGES } },
+    children
+  );
+}
+
+/**
+ * useT() — reads from the shared I18nContext.
+ * Must be called inside <I18nProvider>. Any setLanguage call re-renders the whole tree.
+ */
+export function useT(): I18nContextValue {
+  return useContext(I18nContext);
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
+import "flag-icons/css/flag-icons.min.css";
 import { AppRouter } from "./app/router";
 import { applyStoredTheme } from "./lib/theme";
 import { applyStoredLanguage } from "./lib/i18n";
 
-// Apply persisted preferences before first paint.
+// Apply persisted preferences before first paint (flash prevention).
 applyStoredTheme();
 applyStoredLanguage();
 

--- a/web/src/pages/Containers.tsx
+++ b/web/src/pages/Containers.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { listContainers, getSettings, putSettings } from "../lib/api";
-import type { Container, Settings } from "../lib/api";
+import { listContainers } from "../lib/api";
+import type { Container } from "../lib/api";
 import { useT } from "../lib/i18n";
 import { BackupButton } from "../components/BackupButton";
 import { RestorePanel } from "../components/RestorePanel";
@@ -35,184 +35,90 @@ function StateChip({ state }: { state: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Schedule editor card
+// Sort control
 // ---------------------------------------------------------------------------
 
-type SchedulePreset = "off" | "daily" | "weekly" | "cron";
+type SortKey = "name" | "status" | "ip";
 
-function parsePreset(value: string): SchedulePreset {
-  if (value === "off" || value === "") return "off";
-  if (/^daily\s+\d{1,2}:\d{2}$/.test(value)) return "daily";
-  if (/^weekly\s+\w+\s+\d{1,2}:\d{2}$/.test(value)) return "weekly";
-  return "cron";
+const SORT_STORAGE_KEY = "bv-containers-sort";
+
+function loadSortKey(): SortKey {
+  const v = localStorage.getItem(SORT_STORAGE_KEY);
+  if (v === "name" || v === "status" || v === "ip") return v;
+  return "name";
 }
 
-const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-
-interface ScheduleCardProps {
-  t: ReturnType<typeof useT>["t"];
+/** Parse an IP like "192.168.1.5" into a numeric tuple for numeric-aware sort. */
+function ipToTuple(ip: string): number[] {
+  if (!ip) return [Infinity];
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some(isNaN)) return [Infinity];
+  return parts;
 }
 
-function ScheduleCard({ t }: ScheduleCardProps) {
-  const [settings, setSettings] = useState<Settings | null>(null);
-  const [preset, setPreset] = useState<SchedulePreset>("off");
-  const [dailyTime, setDailyTime] = useState("02:00");
-  const [weeklyDay, setWeeklyDay] = useState("Mon");
-  const [weeklyTime, setWeeklyTime] = useState("02:00");
-  const [cronExpr, setCronExpr] = useState("");
-  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  useEffect(() => {
-    getSettings()
-      .then((res) => {
-        if (!res.ok) return;
-        setSettings(res.settings);
-        const sched = res.settings.containersSchedule ?? "off";
-        const p = parsePreset(sched);
-        setPreset(p);
-        if (p === "daily") {
-          const m = /^daily\s+(\d{1,2}:\d{2})$/.exec(sched);
-          if (m) setDailyTime(m[1]);
-        } else if (p === "weekly") {
-          const m = /^weekly\s+(\w+)\s+(\d{1,2}:\d{2})$/.exec(sched);
-          if (m) { setWeeklyDay(m[1]); setWeeklyTime(m[2]); }
-        } else if (p === "cron") {
-          setCronExpr(sched);
-        }
-      })
-      .catch(() => {/* non-fatal */});
-  }, []);
-
-  function buildValue(): string {
-    if (preset === "off") return "off";
-    if (preset === "daily") return `daily ${dailyTime}`;
-    if (preset === "weekly") return `weekly ${weeklyDay} ${weeklyTime}`;
-    return cronExpr.trim() || "off";
+function compareIPs(a: string, b: string): number {
+  const ta = ipToTuple(a);
+  const tb = ipToTuple(b);
+  for (let i = 0; i < Math.max(ta.length, tb.length); i++) {
+    const diff = (ta[i] ?? 0) - (tb[i] ?? 0);
+    if (diff !== 0) return diff;
   }
+  return 0;
+}
 
-  async function handleSave() {
-    if (!settings) return;
-    setSaveState("saving");
-    setSaveError(null);
-    const updated: Settings = { ...settings, containersSchedule: buildValue() };
-    try {
-      const res = await putSettings(updated);
-      if (res.ok) {
-        setSettings(updated);
-        setSaveState("saved");
-        setTimeout(() => setSaveState("idle"), 3000);
-      } else {
-        setSaveError(res.error ?? "Save failed");
-        setSaveState("error");
-      }
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Save failed");
-      setSaveState("error");
+function sortContainers(containers: Container[], key: SortKey): Container[] {
+  const copy = [...containers];
+  switch (key) {
+    case "name":
+      return copy.sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+      );
+    case "status": {
+      const rank = (c: Container) => (c.state.toLowerCase() === "running" ? 0 : 1);
+      return copy.sort((a, b) => {
+        const r = rank(a) - rank(b);
+        if (r !== 0) return r;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+      });
     }
+    case "ip":
+      return copy.sort((a, b) => {
+        const cmp = compareIPs(a.ip, b.ip);
+        if (cmp !== 0) return cmp;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+      });
   }
+}
 
+const SORT_LABELS: Record<SortKey, string> = {
+  name: "Name (A–Z)",
+  status: "Status",
+  ip: "IP",
+};
+
+function SortControl({
+  value,
+  onChange,
+}: {
+  value: SortKey;
+  onChange: (k: SortKey) => void;
+}) {
   return (
-    <div className="bg-carbon-surface rounded-card border border-carbon-border p-5 flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-carbon-textSub uppercase tracking-widest">
-          {t("containers.schedule")}
-        </h2>
-      </div>
-
-      {/* Preset selector */}
-      <div className="flex flex-wrap gap-2">
-        {(["off", "daily", "weekly", "cron"] as SchedulePreset[]).map((p) => (
-          <button
-            key={p}
-            onClick={() => setPreset(p)}
-            className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-              preset === p
-                ? "bg-carbon-surface3 text-carbon-text"
-                : "bg-carbon-surface2 text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text"
-            }`}
-          >
-            {p === "off" ? t("settings.scheduleOff") : p}
-          </button>
-        ))}
-      </div>
-
-      {/* Fields */}
-      {preset === "daily" && (
-        <div className="flex items-center gap-3">
-          <label className="text-xs text-carbon-textSub w-16">Time</label>
-          <input
-            type="time"
-            value={dailyTime}
-            onChange={(e) => setDailyTime(e.target.value)}
-            className="rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm px-2.5 py-1.5 focus:outline-none focus:border-[#78a9ff]"
-          />
-        </div>
-      )}
-
-      {preset === "weekly" && (
-        <div className="flex items-center gap-3 flex-wrap">
-          <label className="text-xs text-carbon-textSub w-16">Day</label>
-          <select
-            value={weeklyDay}
-            onChange={(e) => setWeeklyDay(e.target.value)}
-            className="rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm px-2.5 py-1.5 focus:outline-none focus:border-[#78a9ff]"
-          >
-            {DAYS.map((d) => <option key={d}>{d}</option>)}
-          </select>
-          <label className="text-xs text-carbon-textSub">at</label>
-          <input
-            type="time"
-            value={weeklyTime}
-            onChange={(e) => setWeeklyTime(e.target.value)}
-            className="rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm px-2.5 py-1.5 focus:outline-none focus:border-[#78a9ff]"
-          />
-        </div>
-      )}
-
-      {preset === "cron" && (
-        <div className="flex items-center gap-3">
-          <label className="text-xs text-carbon-textSub w-16">Cron</label>
-          <input
-            type="text"
-            value={cronExpr}
-            onChange={(e) => setCronExpr(e.target.value)}
-            placeholder="30 2 * * *"
-            spellCheck={false}
-            className="rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm font-mono px-2.5 py-1.5 focus:outline-none focus:border-[#78a9ff] w-44"
-          />
-          <span className="text-xs text-carbon-textMuted">standard 5-field cron</span>
-        </div>
-      )}
-
-      {/* Preview */}
-      <p className="text-xs text-carbon-textMuted">
-        Value: <span className="font-mono text-carbon-textSub">{buildValue()}</span>
-      </p>
-
-      {/* Save */}
-      <div className="flex items-center gap-3">
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-carbon-textMuted">Sort:</span>
+      {(["name", "status", "ip"] as SortKey[]).map((k) => (
         <button
-          onClick={() => void handleSave()}
-          disabled={saveState === "saving" || !settings}
-          className="inline-flex items-center gap-2 rounded-lg bg-carbon-surface3 px-4 py-1.5 text-xs font-medium text-carbon-text hover:bg-carbon-hover transition-colors disabled:opacity-50"
+          key={k}
+          onClick={() => onChange(k)}
+          className={`rounded-lg px-3 py-1 text-xs font-medium transition-colors ${
+            value === k
+              ? "bg-carbon-surface3 text-carbon-text"
+              : "bg-carbon-surface2 text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text"
+          }`}
         >
-          {saveState === "saving" ? (
-            <>
-              <span className="h-3 w-3 rounded-full border-2 border-[#78a9ff] border-t-transparent animate-spin" />
-              Saving…
-            </>
-          ) : (
-            t("settings.save")
-          )}
+          {SORT_LABELS[k]}
         </button>
-        {saveState === "saved" && (
-          <span className="text-xs text-[#6fdc8c]">{t("settings.saved")}</span>
-        )}
-        {saveState === "error" && saveError && (
-          <span className="text-xs text-[#ff8389]">{saveError}</span>
-        )}
-      </div>
+      ))}
     </div>
   );
 }
@@ -239,6 +145,9 @@ function ContainerRow({
               {container.name}
             </span>
             <StateChip state={container.state} />
+            {container.ip && (
+              <span className="text-xs text-carbon-textMuted font-mono">{container.ip}</span>
+            )}
           </div>
           <p className="text-xs text-carbon-textMuted mt-0.5 truncate">{container.image}</p>
         </div>
@@ -281,6 +190,7 @@ export function Containers() {
   const [containers, setContainers] = useState<Container[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>(loadSortKey);
 
   useEffect(() => {
     listContainers()
@@ -291,6 +201,13 @@ export function Containers() {
       .catch(() => setError("Failed to load containers"))
       .finally(() => setLoading(false));
   }, []);
+
+  function handleSortChange(k: SortKey) {
+    setSortKey(k);
+    localStorage.setItem(SORT_STORAGE_KEY, k);
+  }
+
+  const sorted = sortContainers(containers, sortKey);
 
   return (
     <div className="flex flex-col gap-6 max-w-5xl">
@@ -303,9 +220,6 @@ export function Containers() {
           Manage container backups, schedules, and restores.
         </p>
       </div>
-
-      {/* Schedule card */}
-      <ScheduleCard t={t} />
 
       {/* Container list */}
       {loading && (
@@ -323,7 +237,8 @@ export function Containers() {
       )}
       {!loading && containers.length > 0 && (
         <div className="flex flex-col gap-3">
-          {containers.map((c) => (
+          <SortControl value={sortKey} onChange={handleSortChange} />
+          {sorted.map((c) => (
             <ContainerRow key={c.name} container={c} t={t} />
           ))}
         </div>

--- a/web/src/pages/Containers.tsx
+++ b/web/src/pages/Containers.tsx
@@ -57,11 +57,14 @@ function ipToTuple(ip: string): number[] {
 }
 
 function compareIPs(a: string, b: string): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
   const ta = ipToTuple(a);
   const tb = ipToTuple(b);
-  for (let i = 0; i < Math.max(ta.length, tb.length); i++) {
-    const diff = (ta[i] ?? 0) - (tb[i] ?? 0);
-    if (diff !== 0) return diff;
+  for (let i = 0; i < 4; i++) {
+    const d = (ta[i] ?? 0) - (tb[i] ?? 0);
+    if (d !== 0) return d;
   }
   return 0;
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { getSettings, putSettings } from "../lib/api";
+import { useEffect, useState, useCallback } from "react";
+import { getSettings, putSettings, browse } from "../lib/api";
 import type { Settings } from "../lib/api";
 import { useT } from "../lib/i18n";
 import { SpikePanel } from "../components/SpikePanel";
@@ -70,52 +70,6 @@ function ToggleRow({
 }
 
 // ---------------------------------------------------------------------------
-// Path row with preview
-// ---------------------------------------------------------------------------
-
-function PathRow({
-  label,
-  value,
-  hostMountRoot,
-  onChange,
-}: {
-  label: string;
-  value: string;
-  hostMountRoot: string;
-  onChange: (v: string) => void;
-}) {
-  const trimmed = value.trim();
-  const resolved =
-    trimmed && !trimmed.startsWith("/") && !trimmed.includes("..")
-      ? `${hostMountRoot}/${trimmed}`
-      : "";
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-xs text-carbon-textSub">{label}</label>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        spellCheck={false}
-        placeholder="backups/bombvault/containers"
-        className="rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm font-mono px-3 py-1.5 focus:outline-none focus:border-[#78a9ff] w-full"
-      />
-      {resolved && (
-        <p className="text-xs text-carbon-textMuted font-mono">
-          → {resolved}
-        </p>
-      )}
-      {!resolved && trimmed && (
-        <p className="text-xs text-[#ff8389]">
-          Path must be a relative subpath (no leading / or ..)
-        </p>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Save bar shared component
 // ---------------------------------------------------------------------------
 
@@ -159,6 +113,371 @@ function SaveBar({
 }
 
 // ---------------------------------------------------------------------------
+// Folder browser (Feature 3)
+// ---------------------------------------------------------------------------
+
+interface FolderBrowserProps {
+  label: string;
+  value: string;
+  hostMountRoot: string;
+  onChange: (v: string) => void;
+}
+
+function FolderBrowser({ label, value, hostMountRoot, onChange }: FolderBrowserProps) {
+  // browsePath tracks the *current directory being listed* (not the selected value).
+  // We initialise it to the current value so opening the browser starts in the right folder.
+  const [open, setOpen] = useState(false);
+  const [browsePath, setBrowsePath] = useState(value);
+  const [dirs, setDirs] = useState<{ name: string; path: string }[]>([]);
+  const [browseError, setBrowseError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [manualFallback, setManualFallback] = useState(false);
+
+  const doFetch = useCallback((path: string) => {
+    setLoading(true);
+    setBrowseError(null);
+    browse(path)
+      .then((res) => {
+        if (!res.ok) {
+          setBrowseError(res.error ?? "Could not read directory");
+          setManualFallback(true);
+          return;
+        }
+        setDirs(res.dirs ?? []);
+        setBrowsePath(path);
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : "Browse failed";
+        setBrowseError(msg);
+        setManualFallback(true);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleOpen() {
+    setManualFallback(false);
+    setOpen(true);
+    doFetch(value);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    setBrowseError(null);
+  }
+
+  function handleUp() {
+    const parts = browsePath.split("/").filter(Boolean);
+    parts.pop();
+    doFetch(parts.join("/"));
+  }
+
+  function handleSelect() {
+    onChange(browsePath);
+    setOpen(false);
+  }
+
+  const trimmed = value.trim();
+  const resolved =
+    trimmed && !trimmed.startsWith("/") && !trimmed.includes("..")
+      ? `${hostMountRoot}/${trimmed}`
+      : "";
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs text-carbon-textSub">{label}</label>
+
+      {/* Current value + browser trigger */}
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          spellCheck={false}
+          placeholder="backups/bombvault/containers"
+          className="flex-1 rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm font-mono px-3 py-1.5 focus:outline-none focus:border-[#78a9ff]"
+        />
+        <button
+          onClick={handleOpen}
+          title="Browse folders"
+          className="shrink-0 rounded-lg bg-carbon-surface2 border border-carbon-border px-3 py-1.5 text-xs text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text transition-colors"
+        >
+          Browse…
+        </button>
+      </div>
+
+      {/* Absolute path preview */}
+      {resolved && (
+        <p className="text-xs text-carbon-textMuted font-mono">→ {resolved}</p>
+      )}
+      {!resolved && trimmed && (
+        <p className="text-xs text-[#ff8389]">
+          Path must be a relative subpath (no leading / or ..)
+        </p>
+      )}
+
+      {/* Browser panel */}
+      {open && (
+        <div className="mt-1 rounded-lg bg-carbon-surface2 border border-carbon-border p-3 flex flex-col gap-2">
+          {/* Header: current path + close */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-mono text-carbon-textSub truncate">
+              {hostMountRoot}/{browsePath || ""}
+            </span>
+            <button
+              onClick={handleClose}
+              className="text-xs text-carbon-textMuted hover:text-carbon-text shrink-0"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Error state with manual fallback */}
+          {browseError && (
+            <p className="text-xs text-[#ff8389]">{browseError}</p>
+          )}
+
+          {/* Loading spinner */}
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-carbon-textMuted">
+              <span className="h-3 w-3 rounded-full border-2 border-[#78a9ff] border-t-transparent animate-spin" />
+              Loading…
+            </div>
+          )}
+
+          {/* Directory listing */}
+          {!loading && !manualFallback && (
+            <div className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+              {/* ".." go up — only when not at root */}
+              {browsePath !== "" && (
+                <button
+                  onClick={handleUp}
+                  className="text-left text-xs font-mono text-carbon-textSub px-2 py-1 rounded hover:bg-carbon-hover hover:text-carbon-text transition-colors"
+                >
+                  ..
+                </button>
+              )}
+              {dirs.length === 0 && !browseError && (
+                <p className="text-xs text-carbon-textMuted px-2">No subdirectories</p>
+              )}
+              {dirs.map((d) => (
+                <button
+                  key={d.path}
+                  onClick={() => doFetch(d.path)}
+                  className="text-left text-xs font-mono text-carbon-textSub px-2 py-1 rounded hover:bg-carbon-hover hover:text-carbon-text transition-colors"
+                >
+                  {d.name}/
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Action buttons */}
+          {!manualFallback && (
+            <div className="flex items-center gap-2 pt-1 border-t border-carbon-border">
+              <button
+                onClick={handleSelect}
+                className="text-xs rounded-lg bg-carbon-surface3 px-3 py-1 text-carbon-text hover:bg-carbon-hover transition-colors"
+              >
+                Use this folder
+              </button>
+              <span className="text-xs text-carbon-textMuted font-mono truncate">
+                {browsePath || "(root)"}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Schedule cadence builder (Feature 2)
+// ---------------------------------------------------------------------------
+
+type CadenceMode = "off" | "daily" | "weekly" | "everyN";
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+interface CadenceState {
+  mode: CadenceMode;
+  time: string; // "HH:MM"
+  weekdays: string[]; // subset of WEEKDAYS, for weekly
+  intervalDays: number; // for everyN
+}
+
+const DEFAULT_CADENCE: CadenceState = {
+  mode: "off",
+  time: "02:00",
+  weekdays: ["Mon"],
+  intervalDays: 3,
+};
+
+/** Build the grammar string from builder state. */
+function buildCadenceString(s: CadenceState): string {
+  switch (s.mode) {
+    case "off":
+      return "off";
+    case "daily":
+      return `daily ${s.time}`;
+    case "weekly": {
+      const days = WEEKDAYS.filter((d) => s.weekdays.includes(d));
+      const daysStr = days.length > 0 ? days.join(",") : "Mon";
+      return `weekly ${daysStr} ${s.time}`;
+    }
+    case "everyN":
+      return `everyN ${Math.max(1, s.intervalDays)} ${s.time}`;
+  }
+}
+
+/** Parse a stored cadence string back into builder state. */
+function parseCadenceString(raw: string): CadenceState {
+  const s = (raw ?? "").trim();
+  if (!s || s === "off") return { ...DEFAULT_CADENCE, mode: "off" };
+
+  const dailyM = /^daily\s+(\d{1,2}:\d{2})$/.exec(s);
+  if (dailyM) return { mode: "daily", time: dailyM[1], weekdays: ["Mon"], intervalDays: 3 };
+
+  const weeklyM = /^weekly\s+([\w,]+)\s+(\d{1,2}:\d{2})$/.exec(s);
+  if (weeklyM) {
+    const days = weeklyM[1].split(",").map((d) => d.trim());
+    return { mode: "weekly", time: weeklyM[2], weekdays: days, intervalDays: 3 };
+  }
+
+  const everyNM = /^everyN\s+(\d+)\s+(\d{1,2}:\d{2})$/.exec(s);
+  if (everyNM) {
+    return { mode: "everyN", time: everyNM[2], weekdays: ["Mon"], intervalDays: parseInt(everyNM[1], 10) };
+  }
+
+  // Unrecognised (e.g. raw cron from old data) — fall back to off
+  return { ...DEFAULT_CADENCE, mode: "off" };
+}
+
+function CadenceBuilder({
+  label,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const [state, setState] = useState<CadenceState>(() => parseCadenceString(value));
+
+  // Re-parse when the stored value changes externally (e.g. after load or sync checkbox)
+  useEffect(() => {
+    setState(parseCadenceString(value));
+  }, [value]);
+
+  function update(patch: Partial<CadenceState>) {
+    setState((prev) => {
+      const next = { ...prev, ...patch };
+      onChange(buildCadenceString(next));
+      return next;
+    });
+  }
+
+  function toggleWeekday(day: string) {
+    const current = state.weekdays;
+    const next = current.includes(day)
+      ? current.filter((d) => d !== day)
+      : [...current, day];
+    // Always keep at least one weekday selected
+    if (next.length === 0) return;
+    update({ weekdays: next });
+  }
+
+  const inputCls =
+    "rounded-lg bg-carbon-surface2 border border-carbon-border text-carbon-text text-sm px-2.5 py-1.5 focus:outline-none focus:border-[#78a9ff] disabled:opacity-50";
+
+  return (
+    <div className={`flex flex-col gap-3 ${disabled ? "opacity-50 pointer-events-none" : ""}`}>
+      <span className="text-xs text-carbon-textSub font-medium">{label}</span>
+
+      {/* Mode pills */}
+      <div className="flex flex-wrap gap-2">
+        {(["off", "daily", "weekly", "everyN"] as CadenceMode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => update({ mode: m })}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+              state.mode === m
+                ? "bg-carbon-surface3 text-carbon-text"
+                : "bg-carbon-surface2 text-carbon-textSub hover:bg-carbon-hover hover:text-carbon-text"
+            }`}
+          >
+            {m === "off" ? "Off" : m === "daily" ? "Daily" : m === "weekly" ? "Weekly" : "Every N days"}
+          </button>
+        ))}
+      </div>
+
+      {/* Time picker — shown for all non-off modes */}
+      {state.mode !== "off" && (
+        <div className="flex items-center gap-3">
+          <label className="text-xs text-carbon-textMuted w-16">Time</label>
+          <input
+            type="time"
+            value={state.time}
+            onChange={(e) => update({ time: e.target.value })}
+            className={inputCls}
+          />
+        </div>
+      )}
+
+      {/* Weekly: weekday checkboxes */}
+      {state.mode === "weekly" && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <label className="text-xs text-carbon-textMuted w-16">Days</label>
+          <div className="flex flex-wrap gap-1.5">
+            {WEEKDAYS.map((d) => (
+              <button
+                key={d}
+                onClick={() => toggleWeekday(d)}
+                className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                  state.weekdays.includes(d)
+                    ? "bg-[#1c3a2a] text-[#6fdc8c] border border-[#2a5540]"
+                    : "bg-carbon-surface2 text-carbon-textSub border border-carbon-border hover:bg-carbon-hover"
+                }`}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Every N days: number input */}
+      {state.mode === "everyN" && (
+        <div className="flex items-center gap-3">
+          <label className="text-xs text-carbon-textMuted w-16">Every</label>
+          <input
+            type="number"
+            min={1}
+            value={state.intervalDays}
+            onChange={(e) => {
+              const n = parseInt(e.target.value, 10);
+              if (!isNaN(n) && n >= 1) update({ intervalDays: n });
+            }}
+            className={`${inputCls} w-20`}
+          />
+          <span className="text-xs text-carbon-textMuted">days</span>
+        </div>
+      )}
+
+      {/* Preview */}
+      {state.mode !== "off" && (
+        <p className="text-xs text-carbon-textMuted">
+          Value:{" "}
+          <span className="font-mono text-carbon-textSub">{buildCadenceString(state)}</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Settings page
 // ---------------------------------------------------------------------------
 
@@ -179,12 +498,28 @@ export function SettingsPage() {
   const [domSaveState, setDomSaveState] = useState<SaveState>("idle");
   const [domSaveError, setDomSaveError] = useState<string | null>(null);
 
+  const [schedSaveState, setSchedSaveState] = useState<SaveState>("idle");
+  const [schedSaveError, setSchedSaveError] = useState<string | null>(null);
+
+  // "Use containers schedule for VMs and Flash too" checkbox
+  const [syncSchedules, setSyncSchedules] = useState(false);
+
   useEffect(() => {
     getSettings()
       .then((res) => {
         if (res.ok) {
           setSettings(res.settings);
           if (res.hostMountRoot) setHostMountRoot(res.hostMountRoot);
+          // Detect if schedules are already in sync
+          const s = res.settings;
+          if (
+            s.vmsSchedule === s.containersSchedule &&
+            s.flashSchedule === s.containersSchedule &&
+            s.containersSchedule !== "off" &&
+            s.containersSchedule !== ""
+          ) {
+            setSyncSchedules(true);
+          }
         } else {
           setLoadError("Failed to load settings");
         }
@@ -237,6 +572,21 @@ export function SettingsPage() {
     );
   }
 
+  // Build the schedule patch (used by the Schedule save button)
+  function buildSchedulePatch(): Partial<Settings> {
+    const patch: Partial<Settings> = {
+      containersSchedule: settings!.containersSchedule,
+    };
+    if (syncSchedules) {
+      patch.vmsSchedule = settings!.containersSchedule;
+      patch.flashSchedule = settings!.containersSchedule;
+    } else {
+      patch.vmsSchedule = settings!.vmsSchedule;
+      patch.flashSchedule = settings!.flashSchedule;
+    }
+    return patch;
+  }
+
   return (
     <div className="flex flex-col gap-6 max-w-3xl">
       {/* Page heading */}
@@ -287,10 +637,10 @@ export function SettingsPage() {
       <Card title={t("settings.paths")}>
         <p className="text-xs text-carbon-textMuted -mt-1">
           Relative subpaths under the host mount root (
-          <span className="font-mono">{hostMountRoot}</span>). The resolved
-          absolute path is shown as a preview.
+          <span className="font-mono">{hostMountRoot}</span>). Click Browse to
+          navigate directories or type a path directly.
         </p>
-        <PathRow
+        <FolderBrowser
           label={t("settings.containersPath")}
           value={settings.containersPath}
           hostMountRoot={hostMountRoot}
@@ -298,7 +648,7 @@ export function SettingsPage() {
             setSettings((prev) => prev ? { ...prev, containersPath: v } : prev)
           }
         />
-        <PathRow
+        <FolderBrowser
           label={t("settings.vmsPath")}
           value={settings.vmsPath}
           hostMountRoot={hostMountRoot}
@@ -306,7 +656,7 @@ export function SettingsPage() {
             setSettings((prev) => prev ? { ...prev, vmsPath: v } : prev)
           }
         />
-        <PathRow
+        <FolderBrowser
           label={t("settings.flashPath")}
           value={settings.flashPath}
           hostMountRoot={hostMountRoot}
@@ -328,6 +678,86 @@ export function SettingsPage() {
               setPathSaveError
             )
           }
+          t={t}
+        />
+      </Card>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Schedule                                                             */}
+      {/* ------------------------------------------------------------------ */}
+      <Card title={t("settings.schedule")}>
+        <p className="text-xs text-carbon-textMuted -mt-1">
+          Configure when automatic backups run per domain.
+        </p>
+
+        {/* Containers schedule */}
+        <div className="rounded-lg bg-carbon-surface2 border border-carbon-border p-4">
+          <CadenceBuilder
+            label="Containers"
+            value={settings.containersSchedule}
+            onChange={(v) =>
+              setSettings((prev) =>
+                prev ? { ...prev, containersSchedule: v } : prev
+              )
+            }
+          />
+        </div>
+
+        {/* Sync checkbox */}
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={syncSchedules}
+            onChange={(e) => setSyncSchedules(e.target.checked)}
+            className="h-4 w-4 rounded border-carbon-border bg-carbon-surface2 accent-[#6fdc8c]"
+          />
+          <span className="text-sm text-carbon-text">
+            Use the Containers schedule for VMs and Flash too
+          </span>
+        </label>
+
+        {/* VMs schedule */}
+        <div className={`rounded-lg bg-carbon-surface2 border border-carbon-border p-4 ${syncSchedules ? "opacity-50" : ""}`}>
+          <CadenceBuilder
+            label="VMs (later phase)"
+            value={syncSchedules ? settings.containersSchedule : settings.vmsSchedule}
+            disabled={syncSchedules}
+            onChange={(v) =>
+              setSettings((prev) =>
+                prev ? { ...prev, vmsSchedule: v } : prev
+              )
+            }
+          />
+          {!syncSchedules && (
+            <p className="text-xs text-carbon-textMuted mt-2">
+              Note: VM backup executor is not yet implemented in Phase 1 — schedule is stored but not executed.
+            </p>
+          )}
+        </div>
+
+        {/* Flash schedule */}
+        <div className={`rounded-lg bg-carbon-surface2 border border-carbon-border p-4 ${syncSchedules ? "opacity-50" : ""}`}>
+          <CadenceBuilder
+            label="Flash (later phase)"
+            value={syncSchedules ? settings.containersSchedule : settings.flashSchedule}
+            disabled={syncSchedules}
+            onChange={(v) =>
+              setSettings((prev) =>
+                prev ? { ...prev, flashSchedule: v } : prev
+              )
+            }
+          />
+          {!syncSchedules && (
+            <p className="text-xs text-carbon-textMuted mt-2">
+              Note: Flash backup executor is not yet implemented in Phase 1 — schedule is stored but not executed.
+            </p>
+          )}
+        </div>
+
+        <SaveBar
+          state={schedSaveState}
+          error={schedSaveError}
+          onSave={() => void save(buildSchedulePatch(), setSchedSaveState, setSchedSaveError)}
           t={t}
         />
       </Card>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -60,7 +60,7 @@ function ToggleRow({
         }`}
       >
         <span
-          className={`inline-block h-3.5 w-3.5 rounded-full bg-[#161616] transition-transform ${
+          className={`inline-block h-3.5 w-3.5 rounded-full bg-carbon-background transition-transform ${
             checked ? "translate-x-[18px]" : "translate-x-[3px]"
           }`}
         />
@@ -340,7 +340,10 @@ function parseCadenceString(raw: string): CadenceState {
 
   const weeklyM = /^weekly\s+([\w,]+)\s+(\d{1,2}:\d{2})$/.exec(s);
   if (weeklyM) {
-    const days = weeklyM[1].split(",").map((d) => d.trim());
+    const days = weeklyM[1]
+      .split(",")
+      .map((d) => d.trim())
+      .map((d) => d.charAt(0).toUpperCase() + d.slice(1).toLowerCase());
     return { mode: "weekly", time: weeklyM[2], weekdays: days, intervalDays: 3 };
   }
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -5,17 +5,18 @@ export default {
   theme: {
     extend: {
       colors: {
-        // IBM Carbon monochrome palette
+        // IBM Carbon palette — values are CSS custom properties so that
+        // toggling data-theme on <html> instantly re-colours the whole app.
         carbon: {
-          background: "#161616",   // deepest bg
-          surface:    "#262626",   // card / sidebar surface
-          surface2:   "#393939",   // elevated surface / border
-          surface3:   "#525252",   // subtle accent / selected
-          text:       "#f4f4f4",   // primary text
-          textSub:    "#c6c6c6",   // secondary text
-          textMuted:  "#8d8d8d",   // muted / placeholder
-          border:     "#393939",   // border
-          hover:      "#353535",   // hover state
+          background: "var(--carbon-bg)",
+          surface:    "var(--carbon-surface)",
+          surface2:   "var(--carbon-surface2)",
+          surface3:   "var(--carbon-surface3)",
+          text:       "var(--carbon-text)",
+          textSub:    "var(--carbon-text-sub)",
+          textMuted:  "var(--carbon-text-muted)",
+          border:     "var(--carbon-border)",
+          hover:      "var(--carbon-hover)",
         },
       },
       borderRadius: {


### PR DESCRIPTION
Phase 1.1 — box-gate UX fixes + features (on top of the backup-path fix already on main).

**Bugs fixed**
- Language switching is now global (i18n React **Context**) with a **flag-based switcher** + a 26-locale registry (en/de full; the rest fall back to en).
- Light/Dark toggle now actually re-colours: the IBM-Carbon palette is driven by **CSS variables** with a real light + dark set.

**Features**
- Container **sort**: by Name, by Status (running/stopped), by IP (numeric-aware).
- Per-domain **schedule builder** moved to Settings: Off / Daily / Weekly (weekday checkboxes) / Every-N-days + a time picker, plus a "use the containers schedule for VMs + Flash" option.
- Server-side **folder browser** for the backup paths (`GET /api/browse`).

**Backend**
- Container IP in `/api/containers`; richer `ParseCadence` (weekly multi-DOW, `everyN`) with the everyN **due-gate** wired via `ReloadWithDueChecks`.

**Review**: fixed light-mode knob/logo colours, IP-sort stability, weekday round-trip. Gates green (go test + golangci v2 = 0, tsc, vite build, multi-arch image).
