### PR TITLE
fix: reconcile restic encryption mode against the existing repo (#14)

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -55,6 +55,10 @@ type containerDefinition struct {
 // satisfies it directly in production.
 type ResticEngine interface {
 	Init(ctx context.Context, repo string, mode restic.Mode) error
+	// RepoOpens reports whether the repo can be opened (and decrypted) with mode —
+	// a cheap existence + encryption-mode probe (`restic cat config`). Used by
+	// EnsureRepo to reconcile the configured mode against the repo's actual mode.
+	RepoOpens(ctx context.Context, repo string, mode restic.Mode) bool
 	Backup(ctx context.Context, repo string, paths, tags []string, mode restic.Mode) (restic.Summary, error)
 	RestorePath(ctx context.Context, repo, snapshotID, path string, mode restic.Mode) error
 	// DumpZip streams a snapshot subtree (rooted at subfolder) as a zip into w
@@ -402,44 +406,87 @@ func (s *Service) ReplicateOffsite(ctx context.Context, domain string) error {
 	return s.copyToOffsite(ctx, domain, settings, s.ModeFor(settings), localRepo)
 }
 
-// EnsureRepo creates the repo directory and initialises the restic repo on first
-// use. It is idempotent: an already-initialised repo (a `config` marker file
-// present) skips Init, and an Init that reports an already-existing repo is
-// tolerated.
+// EnsureRepo makes sure the restic repo at repo is ready to use with the
+// configured encryption mode. It is idempotent AND reconciles the mode:
+//
+//   - opens with mode                  → exists and consistent; nothing to do
+//   - opens only with the opposite mode → the Encryption setting was toggled
+//     against an existing repo; return a clear, actionable error instead of
+//     letting every later restic call fail cryptically
+//   - opens with neither mode          → not initialised yet, so create it
+//
+// The probe is `restic cat config` (cheap, needs no lock). Telling a real mode
+// mismatch apart from a not-yet-created repo is what stops a flipped Encryption
+// setting from silently breaking backups (issue #14).
 func (s *Service) EnsureRepo(ctx context.Context, repo string, mode restic.Mode) error {
-	// Remote (rclone/off-site) repos have no local directory or `config` marker
-	// to stat. Probe by listing snapshots first: success means the repo already
-	// exists, so skip Init — otherwise every backup re-runs `restic init` against
-	// an existing repo and logs a scary (but harmless) "config file already
-	// exists". Only Init when the probe fails, tolerating a concurrent-create race.
-	if restic.IsRemoteRepo(repo) {
-		if _, probeErr := s.engine.Snapshots(ctx, repo, mode); probeErr == nil {
-			return nil
-		}
-		if err := s.engine.Init(ctx, repo, mode); err != nil && !strings.Contains(strings.ToLower(err.Error()), "already") {
-			return fmt.Errorf("init repo: %w", err)
-		}
+	// Fast path: the repo opens with the configured mode → it exists and its
+	// encryption mode matches. This is the common case on every backup after the
+	// first, and it replaces the old `config`-marker stat (which never checked the
+	// mode) with one that does.
+	if s.engine.RepoOpens(ctx, repo, mode) {
 		return nil
 	}
-	if err := paths.EnsureDir(repo); err != nil {
-		return fmt.Errorf("ensure repo dir: %w", err)
+	// It did not open. Probe the OPPOSITE encryption mode (same backend creds): if
+	// that opens it, the repo exists but was created under the other mode — the
+	// user toggled the Encryption setting. Fail fast with an actionable message
+	// rather than running Init (which would log "config already exists") and then
+	// failing every subsequent backup against the now-mismatched repo.
+	if s.engine.RepoOpens(ctx, repo, s.oppositeMode(mode)) {
+		return fmt.Errorf("this backup repository was created %s, but the Encryption setting is now %s — "+
+			"restic cannot open it after the change. Set Encryption back to %s, or point this backup at a "+
+			"new, empty repository location",
+			encryptionWord(!mode.Encrypted), enabledWord(mode.Encrypted), enabledWord(!mode.Encrypted))
 	}
-	// A restic repository always has a top-level `config` file; its presence is
-	// the cheap, binary-free idempotency check.
-	if _, err := os.Stat(filepath.Join(repo, "config")); err == nil {
-		return nil // already initialised
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("stat repo: %w", err)
+	// Opens with neither mode → treat as not initialised (or a brand-new location)
+	// and create it. Local repos need their directory created first; remote
+	// backends do not.
+	if !restic.IsRemoteRepo(repo) {
+		if err := paths.EnsureDir(repo); err != nil {
+			return fmt.Errorf("ensure repo dir: %w", err)
+		}
 	}
 	if err := s.engine.Init(ctx, repo, mode); err != nil {
 		// Tolerate a race / pre-existing repo: the scrubbed adapter error may not
-		// name the cause, so re-check the marker before failing.
-		if _, statErr := os.Stat(filepath.Join(repo, "config")); statErr == nil { //nolint:gosec // G703: repo is an operator-configured location (settings path or its off-site sibling), validated under the mount root on save; source only selects which configured location, never a raw path
+		// name the cause, so re-probe with the configured mode before failing.
+		if s.engine.RepoOpens(ctx, repo, mode) {
 			return nil
 		}
-		return fmt.Errorf("init repo: %w", err)
+		if !strings.Contains(strings.ToLower(err.Error()), "already") {
+			return fmt.Errorf("init repo: %w", err)
+		}
 	}
 	return nil
+}
+
+// oppositeMode returns mode with its encryption flag flipped, preserving backend
+// credentials (Env). The encrypted variant carries the APP_KEY-derived repo
+// password so a probe can actually open an encrypted repo; the unencrypted
+// variant clears it.
+func (s *Service) oppositeMode(mode restic.Mode) restic.Mode {
+	o := mode
+	o.Encrypted = !mode.Encrypted
+	if o.Encrypted {
+		o.Password = restickey.Derive(s.cfg.AppKey)
+	} else {
+		o.Password = ""
+	}
+	return o
+}
+
+// enabledWord renders an Encryption setting state in the UI's wording.
+func enabledWord(encrypted bool) string {
+	if encrypted {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+// encryptionWord renders a repository's actual encryption mode.
+func encryptionWord(encrypted bool) string {
+	if encrypted {
+		return "encrypted"
+	}
+	return "unencrypted"
 }
 
 // resolveAppdataPaths returns the CONTAINER-VISIBLE paths to back up for a

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -53,6 +53,73 @@ func TestServiceEnsureRepoIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestEnsureRepoReconcilesEncryptionMode(t *testing.T) {
+	newSvc := func(t *testing.T, eng *fakeResticEngine) (*api.Service, string) {
+		t.Helper()
+		dir := t.TempDir()
+		cfg := config.Config{AppKey: strings.Repeat("a", 64), DataDir: dir, HostMountRoot: dir}
+		st := newMemStore(t)
+		return api.NewService(cfg, st, &fakeServiceDocker{}, fakeVirsh{}, eng), filepath.Join(dir, "repo")
+	}
+	enc := restic.Mode{Encrypted: true, Password: "pw"}
+	plain := restic.Mode{Encrypted: false}
+
+	t.Run("existing unencrypted, setting now encrypted → mismatch error, no init", func(t *testing.T) {
+		no := false
+		eng := &fakeResticEngine{existingMode: &no}
+		svc, repo := newSvc(t, eng)
+		err := svc.EnsureRepo(context.Background(), repo, enc)
+		if err == nil {
+			t.Fatal("expected a mode-mismatch error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Encryption") {
+			t.Fatalf("error should name the Encryption setting: %v", err)
+		}
+		if len(eng.inited) != 0 {
+			t.Fatalf("must not init on a mode mismatch, got %v", eng.inited)
+		}
+	})
+
+	t.Run("existing encrypted, setting now unencrypted → mismatch error, no init", func(t *testing.T) {
+		yes := true
+		eng := &fakeResticEngine{existingMode: &yes}
+		svc, repo := newSvc(t, eng)
+		err := svc.EnsureRepo(context.Background(), repo, plain)
+		if err == nil {
+			t.Fatal("expected a mode-mismatch error, got nil")
+		}
+		if len(eng.inited) != 0 {
+			t.Fatalf("must not init on a mode mismatch, got %v", eng.inited)
+		}
+	})
+
+	// Regression guard: the v2.7.0 attempt broke the default unencrypted setup on
+	// the 2nd+ run. A consistent repo must open cleanly and never re-init.
+	t.Run("existing unencrypted, setting still unencrypted → ok, no init", func(t *testing.T) {
+		no := false
+		eng := &fakeResticEngine{existingMode: &no}
+		svc, repo := newSvc(t, eng)
+		if err := svc.EnsureRepo(context.Background(), repo, plain); err != nil {
+			t.Fatalf("consistent unencrypted repo must open cleanly: %v", err)
+		}
+		if len(eng.inited) != 0 {
+			t.Fatalf("must not re-init an existing repo, got %v", eng.inited)
+		}
+	})
+
+	t.Run("existing encrypted, setting still encrypted → ok, no init", func(t *testing.T) {
+		yes := true
+		eng := &fakeResticEngine{existingMode: &yes}
+		svc, repo := newSvc(t, eng)
+		if err := svc.EnsureRepo(context.Background(), repo, enc); err != nil {
+			t.Fatalf("consistent encrypted repo must open cleanly: %v", err)
+		}
+		if len(eng.inited) != 0 {
+			t.Fatalf("must not re-init an existing repo, got %v", eng.inited)
+		}
+	})
+}
+
 func TestServiceModeEncryptionOn(t *testing.T) {
 	cfg := config.Config{AppKey: strings.Repeat("a", 64), HostMountRoot: t.TempDir()}
 	st := newMemStore(t)
@@ -1115,11 +1182,28 @@ type fakeResticEngine struct {
 	// block, when non-nil, makes Backup wait on it — lets a test hold a batch
 	// run "in flight" to exercise the single-batch (409) guard deterministically.
 	block chan struct{}
+	// existingMode, when non-nil, simulates an already-created repo of that
+	// encryption mode: RepoOpens then returns true only for a probe whose mode
+	// matches. When nil, RepoOpens mirrors a local repo and "opens" once restic's
+	// `config` marker exists on disk (mode-agnostic).
+	existingMode *bool
 }
 
 func (f *fakeResticEngine) Init(_ context.Context, repo string, _ restic.Mode) error {
 	f.inited = append(f.inited, repo)
 	return f.initErr
+}
+
+func (f *fakeResticEngine) RepoOpens(_ context.Context, repo string, m restic.Mode) bool {
+	// Simulated existing repo of a pinned mode: opens only when the probe mode
+	// matches (lets a test exercise the encryption-mode-mismatch path).
+	if f.existingMode != nil {
+		return m.Encrypted == *f.existingMode
+	}
+	// Otherwise mirror a real local repo: it "opens" once restic's config marker
+	// exists on disk, regardless of mode. Keeps the idempotency test meaningful.
+	_, err := os.Stat(filepath.Join(repo, "config"))
+	return err == nil
 }
 
 func (f *fakeResticEngine) Backup(_ context.Context, repo string, paths, _ []string, _ restic.Mode) (restic.Summary, error) {

--- a/internal/restic/restic.go
+++ b/internal/restic/restic.go
@@ -97,6 +97,19 @@ func InitArgs(repo string, m Mode) []string {
 	return args
 }
 
+// CatConfigArgs returns the argv slice for `restic cat config`. Reading the
+// config is the minimal operation that opens AND decrypts a repository, so it is
+// the cheapest probe for both "does this repo exist?" and "does mode m open it?"
+// (a wrong encryption mode / password fails to decrypt the config).
+func CatConfigArgs(repo string, m Mode) []string {
+	args := repoFlag(repo)
+	args = append(args, "cat", "config")
+	if !m.Encrypted {
+		args = append(args, insecureFlag)
+	}
+	return args
+}
+
 // BackupArgs returns the argv slice for `restic backup`.
 // Tags are added with --tag; paths are placed after -- (arg-injection guard).
 func BackupArgs(repo string, paths []string, tags []string, m Mode) []string {
@@ -564,6 +577,17 @@ func subcommand(args []string) string {
 func (r Restic) Init(ctx context.Context, repo string, m Mode) error {
 	_, err := r.run(ctx, InitArgs(repo, m), m)
 	return err
+}
+
+// RepoOpens reports whether the repository at repo can be opened (and its config
+// decrypted) using mode m. It runs `restic cat config` — the cheapest read that
+// exercises the repo key — and treats any error (repo missing, wrong encryption
+// mode/password, backend unreachable) as "does not open". It needs no lock, so a
+// concurrently-locked repo still reports true. Used to reconcile the configured
+// encryption mode against the mode the repo was actually created with.
+func (r Restic) RepoOpens(ctx context.Context, repo string, m Mode) bool {
+	_, err := r.run(ctx, CatConfigArgs(repo, m), m)
+	return err == nil
 }
 
 // Backup backs up paths into the repo, tagging each snapshot with tags, and

--- a/internal/restic/restic_args_test.go
+++ b/internal/restic/restic_args_test.go
@@ -24,6 +24,23 @@ func TestInitArgs(t *testing.T) {
 	})
 }
 
+func TestCatConfigArgs(t *testing.T) {
+	t.Run("encrypted", func(t *testing.T) {
+		got := restic.CatConfigArgs("/repo", restic.Mode{Encrypted: true, Password: "pw"})
+		want := []string{"-r", "/repo", "cat", "config"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+	t.Run("unencrypted adds insecure flag", func(t *testing.T) {
+		got := restic.CatConfigArgs("/repo", restic.Mode{Encrypted: false})
+		want := []string{"-r", "/repo", "cat", "config", "--insecure-no-password"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	})
+}
+
 func TestForgetPolicyArgs(t *testing.T) {
 	t.Run("emits only set dimensions + prune", func(t *testing.T) {
 		got := restic.ForgetPolicyArgs("/repo",


### PR DESCRIPTION
Closes #14.

## Problem

`Service.EnsureRepo` decided the restic encryption mode **per run** from the `EncryptionEnabled` setting (`ModeFor`) and only verified that the repo **existed** — a local `config` stat, or a remote `snapshots` probe. It never checked that the repo's *actual* mode matched the configured one. So flipping Encryption against an existing repo sailed through `EnsureRepo` and then failed every later restic call with a cryptic, unactionable error.

The v2.7.0 attempt to fix this inspected the filesystem for a `keys/` directory — wrong, because restic writes a wrapped master key under `keys/` even for `--insecure-no-password` repos, so it flagged *every* repo as encrypted and would have broken the default unencrypted setup after the first backup. It was reverted.

## Approach — probe-based, not filesystem inspection

`EnsureRepo` now opens the repo with `restic cat config` (the cheapest read that exercises the repo key; no lock needed):

| Probe result | Meaning | Action |
|---|---|---|
| opens with the configured mode | exists & consistent | proceed |
| opens only with the **opposite** mode | Encryption toggled against an existing repo | **fail fast** with a clear message naming the setting |
| opens with neither mode | not initialised yet | create it (local: mkdir first; remote: init) |

The mismatch error is plain and actionable, e.g.:

> this backup repository was created unencrypted, but the Encryption setting is now enabled — restic cannot open it after the change. Set Encryption back to disabled, or point this backup at a new, empty repository location

## Changes

- `internal/restic/restic.go`: add `CatConfigArgs` and `Restic.RepoOpens` (lockless open/decrypt probe).
- `internal/api/service.go`: add `RepoOpens` to the `ResticEngine` seam; rewrite `EnsureRepo` to reconcile the mode; add `oppositeMode` (flips encryption, keeps backend creds, derives the APP_KEY password for the encrypted probe) + small wording helpers.
- Tests: `TestEnsureRepoReconcilesEncryptionMode` (mismatch both directions → error + no init; both consistent directions → ok + no init, the **regression guard** for the default unencrypted setup), `TestCatConfigArgs`. Existing `TestServiceEnsureRepoIsIdempotent` still passes.

## Verification

`go build ./...`, `go vet`, `gofmt -l`, and the **full** `go test ./...` suite all pass locally (Go 1.26).

> Note: CI lints only Dockerfile/shell (hadolint + shellcheck) — it does not build or test the Go code — so this was verified locally.