### PR TITLE
fix: retention/prune skipped snapshots after a container update (group forget by paths)

### DIFF
--- a/internal/restic/restic.go
+++ b/internal/restic/restic.go
@@ -83,6 +83,13 @@ func (r Restic) bin() string {
 // insecureFlag is the restic flag for password-less repos (requires restic ≥0.17).
 const insecureFlag = "--insecure-no-password"
 
+// backupHost is a fixed restic --host for every backup. restic otherwise defaults
+// host to the machine hostname, which inside a container is a random short
+// container ID that changes whenever the container is recreated (e.g. on update).
+// Pinning it keeps a target's snapshots under one host so retention can group and
+// prune them together — see ForgetPolicyArgs.
+const backupHost = "bombvault"
+
 // repoFlag returns the common leading args for every restic subcommand.
 func repoFlag(repo string) []string {
 	return []string{"-r", repo}
@@ -119,6 +126,10 @@ func BackupArgs(repo string, paths []string, tags []string, m Mode) []string {
 		args = append(args, insecureFlag)
 	}
 	args = append(args, "--json")
+	// Pin a stable host (see backupHost) so a target's snapshots stay in one
+	// restic group across container recreations; otherwise retention silently
+	// stops collapsing snapshots after an update.
+	args = append(args, "--host", backupHost)
 	for _, tag := range tags {
 		args = append(args, "--tag", tag)
 	}
@@ -272,6 +283,14 @@ func ForgetPolicyArgs(repo string, p RetentionPolicy, m Mode) []string {
 	if !m.Encrypted {
 		args = append(args, insecureFlag)
 	}
+	// Group by paths only, NOT restic's default host+paths. A target's snapshots
+	// share their paths but may carry different hosts (older snapshots predate the
+	// stable --host, or were taken under a now-gone container hostname). Grouping
+	// by host would apply the keep-policy separately per container incarnation, so
+	// snapshots from before an update would never be pruned — which is why manual
+	// and automatic prune appeared to "do nothing". Grouping by paths collapses a
+	// target's whole history into one group regardless of host.
+	args = append(args, "--group-by", "paths")
 	if p.KeepLast > 0 {
 		args = append(args, "--keep-last", strconv.Itoa(p.KeepLast))
 	}

--- a/internal/restic/restic_args_test.go
+++ b/internal/restic/restic_args_test.go
@@ -45,7 +45,7 @@ func TestForgetPolicyArgs(t *testing.T) {
 	t.Run("emits only set dimensions + prune", func(t *testing.T) {
 		got := restic.ForgetPolicyArgs("/repo",
 			restic.RetentionPolicy{KeepLast: 5, KeepMonthly: 6}, restic.Mode{Encrypted: true})
-		want := []string{"-r", "/repo", "forget", "--keep-last", "5", "--keep-monthly", "6", "--prune"}
+		want := []string{"-r", "/repo", "forget", "--group-by", "paths", "--keep-last", "5", "--keep-monthly", "6", "--prune"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v want %v", got, want)
 		}
@@ -54,7 +54,7 @@ func TestForgetPolicyArgs(t *testing.T) {
 		got := restic.ForgetPolicyArgs("/repo",
 			restic.RetentionPolicy{KeepLast: 3, KeepDaily: 7, KeepWeekly: 4, KeepMonthly: 12},
 			restic.Mode{Encrypted: false})
-		want := []string{"-r", "/repo", "forget", "--insecure-no-password",
+		want := []string{"-r", "/repo", "forget", "--insecure-no-password", "--group-by", "paths",
 			"--keep-last", "3", "--keep-daily", "7", "--keep-weekly", "4", "--keep-monthly", "12", "--prune"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v want %v", got, want)
@@ -97,7 +97,7 @@ func TestRetentionPolicyAny(t *testing.T) {
 
 func TestBackupArgs(t *testing.T) {
 	got := restic.BackupArgs("/repo", []string{"-weird", "/p"}, []string{"container:plex"}, restic.Mode{Encrypted: true})
-	want := []string{"-r", "/repo", "backup", "--json", "--tag", "container:plex", "--", "-weird", "/p"}
+	want := []string{"-r", "/repo", "backup", "--json", "--host", "bombvault", "--tag", "container:plex", "--", "-weird", "/p"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v want %v", got, want)
 	}
@@ -105,7 +105,7 @@ func TestBackupArgs(t *testing.T) {
 
 func TestBackupArgsUnencrypted(t *testing.T) {
 	got := restic.BackupArgs("/repo", []string{"/src"}, []string{"t"}, restic.Mode{Encrypted: false})
-	want := []string{"-r", "/repo", "backup", "--insecure-no-password", "--json", "--tag", "t", "--", "/src"}
+	want := []string{"-r", "/repo", "backup", "--insecure-no-password", "--json", "--host", "bombvault", "--tag", "t", "--", "/src"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v want %v", got, want)
 	}


### PR DESCRIPTION
Fixes the prune/retention issue @manilx reported on the forum: keep-daily set to 3, yet all 9 flash snapshots remained after a manual prune.

## Root cause
`restic backup` ran without `--host`, so every snapshot took the container's hostname, which inside Docker is a random short container ID that changes whenever the container is recreated (an update, a template edit, etc.). `restic forget` groups by `host,paths` by default, so the keep-policy was applied **per container incarnation**: snapshots taken before an update sat in a different host group and were never pruned. Manual and automatic prune appeared to do nothing, especially right after an update.

## Fix
- `forget` now groups by **paths only** (`--group-by paths`), collapsing a target's whole history into one group regardless of host. This also repairs already-accumulated snapshots on the next prune.
- `backup` now pins a stable `--host` (`bombvault`) so future snapshots stay consistent.

## Verification
- Updated the arg unit tests; full `go test ./...`, `go vet`, `gofmt`, and golangci-lint are all green.
- Reproduced with **restic 0.19.0**: three same-path snapshots under three different hosts. `forget --keep-last 1` removes **0** with the default grouping (keeps one per host) but **2** with `--group-by paths` (keeps exactly one) — exactly the reported symptom and its fix.
