### PR TITLE
fix(offsite): make a local off-site replica readable off-box (#138)

### DIFF
--- a/internal/api/offsite_repo_readable_internal_test.go
+++ b/internal/api/offsite_repo_readable_internal_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/junkerderprovinz/bombvault/internal/progress"
+	"github.com/junkerderprovinz/bombvault/internal/restic"
+	"github.com/junkerderprovinz/bombvault/internal/store"
+)
+
+// offsiteReadableFakeEngine embeds ResticEngine (left nil) and overrides only
+// what copyToOffsiteTarget's path touches — same pattern as
+// offsite_progress_heartbeat_internal_test.go. Copy writes a repo tree with the
+// modes restic ACTUALLY produces on a local backend (verified against restic
+// 0.17.3: dirs 0700, pack/config/key files 0400), which is the whole point of
+// the fix under test.
+type offsiteReadableFakeEngine struct {
+	ResticEngine
+	copyDest string
+}
+
+func (f *offsiteReadableFakeEngine) RepoOpens(context.Context, string, restic.Mode) bool { return true }
+
+func (f *offsiteReadableFakeEngine) Unlock(context.Context, string, bool, restic.Mode) error {
+	return nil
+}
+
+func (f *offsiteReadableFakeEngine) Snapshots(context.Context, string, restic.Mode) ([]restic.Snapshot, error) {
+	return nil, nil
+}
+
+func (f *offsiteReadableFakeEngine) Copy(_ context.Context, dest, _ string, _ []string, _ restic.Limits, _ restic.Mode) error {
+	f.copyDest = dest
+	shard := filepath.Join(dest, "data", "00")
+	if err := os.MkdirAll(shard, 0o700); err != nil { //nolint:gosec // G301: deliberately reproducing restic's root-only 0700 tree
+		return err
+	}
+	for _, f := range []string{
+		filepath.Join(dest, "config"),
+		filepath.Join(shard, "cafebabe"),
+	} {
+		if err := os.WriteFile(f, []byte("restic"), 0o400); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// A replicated off-site repo that lands on a mounted share must end up readable
+// by the share's OTHER clients, not just by the root process that wrote it.
+//
+// restic writes a local repo 0700/0400, and until this fix copyToOffsiteTarget
+// left it that way — while every local backup has always run makeRepoReadable
+// over the PRIMARY repo for exactly this reason. On an Unassigned-Devices NFS
+// mount the asymmetry stays invisible (the host reads the share as uid 0 and
+// walks straight through the 0700 dirs); switch the same share to SMB and the
+// CIFS session authenticates as an ordinary user the far side refuses, so the
+// repo folders list but their contents do not (bombvault#138 follow-up,
+// reported by manilx). Pins the destination tree as group+other readable.
+func TestCopyToOffsiteTargetMakesDestinationReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits are not modelled on windows")
+	}
+
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open mem store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(db)
+	settings, err := st.GetSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A local/mounted-share destination: a path RELATIVE to the Host Data mount,
+	// which is what the v7.10.0 off-site wizard now accepts (#138).
+	root := t.TempDir()
+	fake := &offsiteReadableFakeEngine{}
+	svc := &Service{store: st, engine: fake, progress: progress.NewStore()}
+	svc.cfg.HostMountRoot = root
+
+	target := store.OffsiteTarget{ID: "t1", Domain: "containers", Repo: "remotes/nas/bombvault", Enabled: true}
+	if err := svc.copyToOffsiteTarget(context.Background(), "containers", settings, target, filepath.Join(root, "local"), false); err != nil {
+		t.Fatalf("copyToOffsiteTarget: %v", err)
+	}
+
+	dest := filepath.Join(root, "remotes", "nas", "bombvault")
+	if fake.copyDest != dest {
+		t.Fatalf("copy destination = %q, want %q", fake.copyDest, dest)
+	}
+	if err := filepath.WalkDir(dest, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		perm := info.Mode().Perm()
+		want := fs.FileMode(0o044) // group+other read
+		if d.IsDir() {
+			want |= 0o011 // group+other traverse
+		}
+		if perm&want != want {
+			return &modeErr{path: p, perm: perm, want: want}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("off-site replica must be readable off-box: %v", err)
+	}
+}
+
+// modeErr reports the first entry of the replicated tree that stayed root-only.
+type modeErr struct {
+	path string
+	perm fs.FileMode
+	want fs.FileMode
+}
+
+func (e *modeErr) Error() string {
+	return e.path + " has perm " + e.perm.String() + ", missing " + e.want.String()
+}
+
+// A REMOTE off-site destination has no local tree to relax; the guard must skip
+// it rather than let filepath.WalkDir loose on a repo URL.
+func TestMakeOffsiteRepoReadableSkipsRemote(t *testing.T) {
+	for _, repo := range []string{
+		"rest:http://192.168.1.2:8000/containers",
+		"s3:s3.amazonaws.com/bucket/containers",
+		"sftp:user@host:/srv/containers",
+	} {
+		if !restic.IsRemoteRepo(repo) {
+			t.Fatalf("%q must be recognised as a remote repo", repo)
+		}
+		makeOffsiteRepoReadable(repo) // must not panic, must not touch the filesystem
+	}
+}
+
+// A destination that is not there yet — EnsureRepo failed because the share had
+// not mounted (#55) — must be a silent no-op, never a panic or a stray mkdir.
+func TestMakeOffsiteRepoReadableToleratesMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "never-mounted")
+	makeOffsiteRepoReadable(missing)
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("relax pass must not create the destination, stat err = %v", err)
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -2056,6 +2056,18 @@ func (s *Service) copyToOffsiteTarget(ctx context.Context, domain string, settin
 	if rerr != nil {
 		return fmt.Errorf("resolve off-site repo: %w", rerr)
 	}
+	// Relax the DESTINATION repo tree the same way every local backup already
+	// relaxes the primary repo (makeRepoReadable). restic, run as root, writes a
+	// local repo 0700/0400, so an off-site copy that lands on a mounted share is
+	// root-only on the FAR side too: the share's other clients see the repo
+	// folders but nothing inside them. That is exactly what an NFS→SMB switch
+	// exposes — an Unassigned-Devices NFS mount reads the share as uid 0 and sails
+	// through the 0700 dirs, while a CIFS mount authenticates as an ordinary SMB
+	// user whose access the far side denies (issue #138 follow-up). Deferred, so a
+	// copy that fails half-way, or a retention prune that writes fresh index/pack
+	// files after it, is covered too; makeOffsiteRepoReadable skips remote
+	// destinations and a path that is not there yet.
+	defer makeOffsiteRepoReadable(dest)
 	// Per-target restic mode carrying this destination's S3 storage class (see
 	// offsiteModeForTarget: the global class is preserved for a backfilled N=1
 	// target whose class is "").
@@ -3706,6 +3718,34 @@ func makeRepoReadable(repo string) {
 		}
 		return nil
 	})
+}
+
+// makeOffsiteRepoReadable is makeRepoReadable for an off-site DESTINATION repo:
+// the same relax pass every backup already runs on the primary repo, applied to
+// the replica so the far side of a mounted-share destination is readable by the
+// share's non-root clients too.
+//
+// Why the destination needs it at all: restic derives its modes from the repo's
+// existing `data` directory and otherwise defaults to 0700 dirs / 0400 files, so
+// an off-site repo BombVault creates (EnsureRepo → paths.EnsureDir, 0700) stays
+// root-only forever — every pack, index and snapshot file included. On a local
+// repo that never showed, because the operator reads it through the same root
+// process; on a share it decides whether ANY other client can open the replica.
+// Verified against restic 0.17.3: `init` into a 0755 directory still creates
+// data/ and keys/ at 0700 and files at 0400, so relaxing the repo root alone is
+// not enough — the tree has to be walked. Once the walk has run, restic derives
+// group-readable modes for later writes, but still not other-readable ones, so
+// this must run after EVERY replication, exactly like the primary repo's pass.
+//
+// Remote backends have no local tree to chmod and are skipped outright (a bare
+// WalkDir over "rest:http://…" would merely fail, but the guard says so). The
+// repo is encrypted, so group/other READ exposes nothing — the same reasoning
+// makeRepoReadable already documents. Best-effort throughout.
+func makeOffsiteRepoReadable(dest string) {
+	if restic.IsRemoteRepo(dest) {
+		return
+	}
+	makeRepoReadable(dest)
 }
 
 // readStoredDef reads an encrypted definition, preferring the new in-repo location


### PR DESCRIPTION
## What manilx hit

After v7.10.0 made local / mounted-share off-site targets a first-class option (#138), manilx pointed an off-site target at a remote share mounted on Unraid through Unassigned Devices. Over **NFS** the replica syncs and every file is visible. Switch the same share to **SMB** and the repo folders list but nothing inside them does.

## Cause

`makeRepoReadable` exists precisely for this, and its own doc comment says so — *"relaxes a LOCAL restic repo tree so the operator can copy it off-box (e.g. a second drive over SMB) as a non-root user. restic, run as root, writes the repo 0700/0600, which locks a non-root sync tool out of the whole folder."*

It runs after every container / VM / flash / file-set backup, over the **primary** repo. `copyToOffsiteTarget` never ran it over the **destination**. So an off-site replica is created by `EnsureRepo` → `paths.EnsureDir` (0700) and filled by restic at 0700 dirs / 0400 files, owned by root, and stays that way forever.

That is invisible on NFS: Unassigned Devices mounts an NFS export and the host reads it as uid 0, which walks straight through 0700 root-owned directories. A CIFS mount authenticates as an ordinary SMB user instead, and the far side enforces its own POSIX check on that user — so the share root lists (showing the repo folder names) and every directory inside the repo is denied. "I see the folders but not the content in the repo folders."

## Evidence

Verified against restic 0.17.3 (the version we ship), on a real Unraid box:

| repo root at init | `data/` | `keys/` | files |
|---|---|---|---|
| `0700` | `0700` | `0700` | `0400` |
| `0755` | `0700` | `0700` | `0400` |

So relaxing the repo root alone does **not** help — the tree has to be walked. And after the walk (`data/` at 0755), restic derives `0755` dirs but only `0440` files for later writes, still not other-readable. Hence the pass must run after *every* replication, exactly like the primary repo's.

Cross-checked against a live install: primary repos on disk are `drwxr-xr-x root root` / `-r--r--r--` — i.e. 0700/0400 healed by `makeRepoReadable` to 0755/0444. An off-site replica has no such pass and stays 0700/0400.

## The change

One deferred call in `copyToOffsiteTarget`, plus a guarded helper.

Deferred rather than placed after `Copy`, so a copy that fails half-way and a retention prune that writes fresh index/pack files afterwards are both covered. `makeOffsiteRepoReadable` skips remote backends outright (nothing local to chmod) and a destination that never mounted is a silent no-op. The repo is encrypted, so group/other **read** exposes nothing — the same reasoning `makeRepoReadable` already documents.

## Tests

`internal/api/offsite_repo_readable_internal_test.go`:

- `TestCopyToOffsiteTargetMakesDestinationReadable` — drives the real `copyToOffsiteTarget` with a fake engine whose `Copy` writes the tree restic actually produces (0700 dirs, 0400 files) and asserts every entry ends up group+other readable. Confirmed to **fail** without the fix (`has perm -rwx------, missing ----r-xr-x`) and pass with it, on Linux.
- `TestMakeOffsiteRepoReadableSkipsRemote` — `rest:` / `s3:` / `sftp:` destinations are skipped.
- `TestMakeOffsiteRepoReadableToleratesMissingPath` — a never-mounted destination is a no-op and is not created.

Full `internal/api` suite passes on linux/amd64. (`internal/restic`'s `TestRoundtrip` fails on a Windows dev box both with and without this change — pre-existing, unrelated to this diff.)

## Note for the reporter

The fix heals the tree on the next replication, but only where BombVault writes through a mount whose mode changes reach the server — an NFS mount or a local disk, not a CIFS mount (`chmod` over CIFS without UNIX extensions is a no-op). So for an already-broken repo: reconnect the share over NFS once and let one replication run, or fix it far-side with `chmod -R a+rX <repo>`. After that the same data is readable over SMB.
