### PR TITLE
fix(vms): bulk backup no longer silently drops the item after a slow off-site copy

### DIFF
--- a/web/src/lib/backupWatch.test.ts
+++ b/web/src/lib/backupWatch.test.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Regression test for #154: "select all VMs, back up selected" silently
+// skipped exactly one VM (Windows Server 2022) with NO success line, NO
+// failure line, nothing in the activity log at all.
+//
+// Root cause: fireAndWaitRun (the bulk "back up / restore selected" fire-
+// retry-wait helper every batch item runs through) used to give up firing a
+// batch item after a FIXED 30s "busy" retry budget (the old BUSY_RETRY_MS).
+// But the PREVIOUS item's single-flight guard (service.go's batchActive)
+// does not release until that item's entire backup call returns — which
+// includes its own inline, synchronous off-site replication
+// (Service.replicateOffsite, called from BackupVM/Backup AFTER the run row
+// is already marked "success" but BEFORE the wrapping goroutine, and
+// therefore batchActive, releases). The reported activity log shows real
+// inline replications taking 20-40s; a 37s one sits right past the old 30s
+// budget. The next batch item's start() kept getting rejected "a backup is
+// already running" until the retry gave up — and because start() never
+// actually SUCCEEDED for that item, no run was ever recorded for it: nothing
+// to show in the activity log, exactly the silent skip reported.
+//
+// The fix folds the fire-retry budget into the SAME generous watchTimeoutMs
+// deadline already used to wait out a real in-progress backup/restore, so a
+// transient "still releasing" busy signal is retried for as long as a batch
+// item is allowed to run at all, never abandoned on an arbitrary shorter
+// clock. This test pins that: it fails against the pre-fix 30s cap (the
+// batch item never starts) and passes once the retry survives past it.
+// ---------------------------------------------------------------------------
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Run } from "./api";
+
+vi.mock("./api", async () => {
+  const actual = await vi.importActual<typeof import("./api")>("./api");
+  return { ...actual, listRuns: vi.fn() };
+});
+
+import { listRuns } from "./api";
+import { fireAndWaitRun } from "./backupWatch";
+
+const mockedListRuns = vi.mocked(listRuns);
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: "run-1",
+    targetId: "target-1",
+    kind: "backup",
+    status: "success",
+    startedAt: 0,
+    finishedAt: 1,
+    snapshotId: "abc123",
+    bytes: 0,
+    error: "",
+    acknowledged: false,
+    target: "Windows Server 2022",
+    domain: "vm",
+    ...overrides,
+  };
+}
+
+describe("fireAndWaitRun busy-retry (#154)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedListRuns.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps retrying a busy start well past the old 30s cap and still starts + succeeds", async () => {
+    const t0 = Date.now();
+    // No prior runs for this target before we fire.
+    mockedListRuns.mockResolvedValue({ ok: true, runs: [] });
+
+    // Simulate the PREVIOUS batch item's inline off-site replication holding
+    // the shared single-flight guard for 40 real seconds — longer than the
+    // old fixed 30s retry budget, matching the ~37-40s replication windows
+    // visible in the reported activity log.
+    const BUSY_FOR_MS = 40_000;
+    let startCalls = 0;
+    const start = vi.fn(async () => {
+      startCalls++;
+      if (Date.now() - t0 < BUSY_FOR_MS) {
+        return { ok: false, error: "a backup is already running" };
+      }
+      // The guard has freed up: this start actually succeeds and a run gets
+      // recorded — from here on, listRuns() must surface it.
+      mockedListRuns.mockResolvedValue({
+        ok: true,
+        runs: [makeRun({ id: "new-run", status: "success" })],
+      });
+      return { ok: true, started: true };
+    });
+
+    const resultPromise = fireAndWaitRun({
+      kind: "backup",
+      matchRun: (r) => r.domain === "vm" && r.target === "Windows Server 2022",
+      start,
+    });
+
+    // Fast-forward well past the old 30s cap (retry) AND the poll interval
+    // (watch) — the batch item must still complete successfully.
+    await vi.advanceTimersByTimeAsync(70_000);
+
+    await expect(resultPromise).resolves.toEqual({ ok: true });
+    // Proves the helper kept retrying the busy start past the old 30s/30-call
+    // ceiling instead of giving up early.
+    expect(startCalls).toBeGreaterThan(35);
+  });
+});

--- a/web/src/lib/backupWatch.ts
+++ b/web/src/lib/backupWatch.ts
@@ -53,8 +53,6 @@ const POLL_INTERVAL_MS = 2000;
  * just beyond the matching server-side hard cap (12h backups, 48h restores). */
 const WATCH_TIMEOUT_BACKUP_MS = 13 * 60 * 60 * 1000;
 const WATCH_TIMEOUT_RESTORE_MS = 49 * 60 * 60 * 1000;
-/** Retry a busy fire (shared single-flight guard still releasing) this long. */
-const BUSY_RETRY_MS = 30 * 1000;
 /** Once the live progress entry has vanished, allow this many successful run
  * polls to still surface the recorded run before falling back to a generic
  * success (some flows record no run — see the fallback in fire()'s poll). */
@@ -305,11 +303,25 @@ export function useBackupWatch({ progressKey, start, matchRun, kind = "backup", 
 // Bulk "back up / restore selected" actions run their targets one after
 // another. The starts are async and share the server's single-flight guard, so
 // firing them in a tight loop would make every call after the first hit
-// "already running". This helper fires ONE run (retrying briefly while the
-// previous target's guard is still releasing — the guard clears just after the
-// run goes terminal, not the instant we observe it), then waits for the NEW
-// recorded run to reach a terminal state before returning. Correlates by a new
-// run id, never by the client clock (skew matched the wrong or last run).
+// "already running". This helper fires ONE run (retrying while the previous
+// target's guard is still releasing — the guard clears only once the previous
+// target's ENTIRE backup call returns, which on the server includes that
+// target's own inline off-site replication, run synchronously AFTER its run
+// is already marked terminal but BEFORE the guard is released), then waits
+// for the NEW recorded run to reach a terminal state before returning.
+// Correlates by a new run id, never by the client clock (skew matched the
+// wrong or last run).
+//
+// #154: the fire-retry used to give up after a fixed, much shorter budget
+// (30s) than a real inline off-site replication can take (the reported
+// activity log shows 20-40s copies) — so a batch item queued right after a
+// slow-replicating one got silently abandoned: its start() never succeeded,
+// so no run was ever recorded for it, so it vanished from the batch with no
+// success line, no failure line, nothing. The fire-retry and the terminal-
+// wait below now share ONE deadline (watchTimeoutMs) — the same generous
+// ceiling already used to wait out a real in-progress backup/restore — so a
+// transient "still releasing" busy signal is retried for as long as a batch
+// item is allowed to run at all, never abandoned on an arbitrary shorter one.
 // ---------------------------------------------------------------------------
 
 export async function fireAndWaitRun(opts: {
@@ -325,8 +337,10 @@ export async function fireAndWaitRun(opts: {
   } catch {
     // ignore — fall back to the first terminal run for this target.
   }
-  // Fire, retrying only while the guard is still busy from the previous target.
-  const fireDeadline = Date.now() + BUSY_RETRY_MS;
+  // ONE deadline covers both the fire-retry below and the terminal-wait that
+  // follows a successful start (see the header comment for why the two must
+  // not have separate, shorter-than-necessary budgets).
+  const deadline = Date.now() + watchTimeoutMs(opts.kind);
   for (;;) {
     let res: Awaited<ReturnType<StartBackupFn>>;
     try {
@@ -336,11 +350,10 @@ export async function fireAndWaitRun(opts: {
     }
     if (res.ok) break;
     const busy = (res.error ?? "").toLowerCase().includes("already running");
-    if (!busy || Date.now() > fireDeadline) return { ok: false, error: res.error };
+    if (!busy || Date.now() > deadline) return { ok: false, error: res.error };
     await new Promise((r) => setTimeout(r, 1000));
   }
   // Poll the recorded runs until this target's NEW run reaches a terminal state.
-  const deadline = Date.now() + watchTimeoutMs(opts.kind);
   for (;;) {
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     try {


### PR DESCRIPTION
Fixes #154

## Root cause

`fireAndWaitRun` (`web/src/lib/backupWatch.ts`) fires each selected item's backup sequentially in a bulk "back up selected" run, retrying on a fixed 30s budget whenever the server reports its single-flight guard (`batchActive`) is still held by the previous item.

That guard only releases once the ENTIRE previous `BackupVM`/`BackupContainer` call returns - which includes that item's own synchronous off-site replication, running *after* the run is already marked "success" in the DB but *before* the guard is released. The issue's own activity log showed real replications taking 20-40s.

So: whichever item was queued right after one with a longer replication got its backup-start rejected on every retry until the fixed 30s budget ran out - and because `start()` never succeeded, no run row was ever created for it. That's exactly the reported symptom: the VM just vanishes from the batch, no success line, no failure line, nothing in the activity log. Not VM-type/name/state-specific - a race between a client-side retry budget and normal, documented server-side behavior.

## Fix

Removed the separate fixed 30s busy-retry budget. The fire-retry loop now shares the same generous deadline already used to wait out a real in-progress backup/restore (13h for backups, 49h for restores) - a transient "still releasing" signal is retried for as long as a batch item is allowed to run at all, never abandoned on a shorter clock. `backupWatch.ts` is shared by both the VMs and Containers bulk actions, so this covers both.

## Testing

New regression test in `web/src/lib/backupWatch.test.ts` simulates a busy guard held for 40 real seconds (matching the observed replication windows): fails on the pre-fix code (item abandoned after ~31 retries), passes post-fix (item eventually starts and succeeds).

- Frontend: `169 passed (169)` (vitest), `tsc --noEmit` clean, `eslint src` 0 errors
- Go: `go build`, `go vet`, `gofmt -l`, `golangci-lint run` all clean; `go test ./...` passes (one pre-existing Windows-only `internal/restic` failure unrelated to this change, reproduced identically on main)