### PR TITLE
chore(renovate): never pin BombVault's own image in the deploy compose file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,13 @@
       "matchFileNames": ["web/lint-ts/package.json"],
       "matchDepNames": ["typescript"],
       "enabled": false
+    },
+    {
+      "description": "BombVault's OWN published image stays on the floating :latest tag, never a pinned digest. docker:pinDigests (above) is right for build INPUTS — the golang base image in the Dockerfile — but deploy/docker-compose.generic.yml is a file users copy to RUN BombVault, and the Unraid CA template it mirrors installs :latest. A digest there freezes every copy of that file on one build forever, so nobody receives an update, and it silently drifts from the template. Renovate proposed exactly that in #168, which was closed rather than merged.",
+      "matchManagers": ["docker-compose"],
+      "matchDepNames": ["junkerderprovinz/bombvault"],
+      "pinDigests": false,
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
`docker:pinDigests` is right for build **inputs** (the `golang` base image in the Dockerfile) but wrong for `deploy/docker-compose.generic.yml`, which users copy to *run* BombVault.

A pinned digest there freezes every copy of that file on one build forever, so nobody ever receives an update — and it silently drifts from the Unraid CA template, which installs `:latest` (the comment directly above the image line says so).

Renovate proposed exactly that in #168. This rule stops it recurring; #168 itself is closed unmerged.